### PR TITLE
[Add] McCode dat file structured array, other minor improvements

### DIFF
--- a/src/mccode_antlr/config/config_default.yaml
+++ b/src/mccode_antlr/config/config_default.yaml
@@ -15,6 +15,6 @@ mcxtrace:
   prefix: mx
   project: 2
 mccode_pooch:
-  source: https://github.com/McStasMcXtrace/McCode
+  source: https://github.com/mccode-dev/McCode
   registry: https://github.com/g5t/mccode-pooch
   tag: latest

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -282,6 +282,7 @@ class Instr:
             elif replace.lower().endswith('flags'):
                 # Punt, and just replace with the lowercase version of the keyword -- hopefully this was intended
                 flag = sub(f'@{replace}@', f'-l{replace.lower()[:-5]}', flag)
+                logger.warning(f'Guessing that @{replace}@ should be {flag}')
             else:
                 logger.warning(f'Unknown keyword @{replace}@ in dependency string')
         return flag

--- a/src/mccode_antlr/loader/datfile.py
+++ b/src/mccode_antlr/loader/datfile.py
@@ -84,6 +84,15 @@ class DatFileCommon:
         data = combine_scan_data(self.data, other.data)
         return DatFileCommon(Path(), metadata, parameters, variables, data)
 
+    @property
+    def structured(self):
+        from numpy import frombuffer
+        d_types = [(v, self.data.dtype) for v in self.variables]
+        order = list(range(1, self.data.ndim)) + [0]
+        s = frombuffer(self.data.transpose(*order).tobytes(), dtype=d_types)
+        if len(order) > 1:
+            s = s.reshape([self.data.shape[x] for x in order[:-1]])
+        return s
 
 def dim_metadata(length, label_unit, lower_limit, upper_limit) -> dict:
     from numpy import linspace


### PR DESCRIPTION
Loaded McCode `.dat` files will now have a `.structured` property to convert their stored numpy data array into a structured array.

This also incidentally updates the McStasMcXtrace organization URL to its new name, mccode-dev.
And adds STDOUT information when, e.g., `@MCPLFLAGS@` gets turned into `-lmcpl` after no configuration entry for `mcpl` is found.