### PR TITLE
More robust use of the `Flavor` enumerated value

### DIFF
--- a/nightly/mccode_test.py
+++ b/nightly/mccode_test.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from numpy import nan
 
+from mccode_antlr import Flavor
 from mccode_antlr.reader import Registry
 
 NightlyInstrExampleType = TypeVar('NightlyInstrExampleType', bound='NightlyInstrExample')
@@ -174,7 +175,7 @@ def _monitor_name_file_name_match(folder, monitor_name):
     return None
 
 
-def mccode_test_compiler(work_dir, file_path, target, flavor, generator, dump, **kwargs):
+def mccode_test_compiler(work_dir, file_path, target, flavor, dump, **kwargs):
     from pathlib import Path
     from mccode_antlr.reader import Reader
     from mccode_antlr.compiler.c import compile_instrument
@@ -186,7 +187,7 @@ def mccode_test_compiler(work_dir, file_path, target, flavor, generator, dump, *
     config = dict(default_main=True, enable_trace=False, portable=False, include_runtime=True,
                   embed_instrument_file=False, verbose=False)
     try:
-        binary_path = compile_instrument(inst, target, output, generator=generator, config=config, dump_source=dump, **kwargs)
+        binary_path = compile_instrument(inst, target, output, flavor=flavor, config=config, dump_source=dump, **kwargs)
     except RuntimeError as err:
         logger.critical(f'Failed to produce a binary for {file_path}')
         logger.info(err)
@@ -195,13 +196,11 @@ def mccode_test_compiler(work_dir, file_path, target, flavor, generator, dump, *
 
 
 def mcstas_test_compiler(target, work_dir, file_path, dump, **kwargs):
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR
-    return mccode_test_compiler(work_dir, file_path, target, 'mcstas', MCSTAS_GENERATOR, dump, **kwargs)
+    return mccode_test_compiler(work_dir, file_path, target, Flavor.MCSTAS, dump, **kwargs)
 
 
 def mcxtrace_test_compiler(target, work_dir, file_path, dump, **kwargs):
-    from mccode_antlr.translators.target import MCXTRACE_GENERATOR
-    return mccode_test_compiler(work_dir, file_path, target, 'mcxtrace', MCXTRACE_GENERATOR, dump, **kwargs)
+    return mccode_test_compiler(work_dir, file_path, target, Flavor.MCXTRACE, dump, **kwargs)
 
 
 def mccode_test_runner(target, binary_path, test_parameters: str, n_particles: int):

--- a/src/mccode_antlr/__init__.py
+++ b/src/mccode_antlr/__init__.py
@@ -6,14 +6,26 @@ __affiliation__ = "European Spallation Source ERIC"
 from .version import version
 __version__ = version()
 
-from enum import Enum
+from enum import IntEnum
 
-class Flavor(Enum):
+class Flavor(IntEnum):
+    """The specializations of the McCode language.
+
+    Enumerated _values_ follow the McCode _project_ number.
+    """
     MCSTAS=1
     MCXTRACE=2
 
     def __str__(self):
-        return 'McStas' if self==Flavor.MCSTAS else 'McXtrace'
+        options = {Flavor.MCSTAS: 'McStas', Flavor.MCXTRACE: 'McXTrace'}
+        return options[self]
+
+    def url(self) -> str:
+        options = {
+            Flavor.MCSTAS: 'https://www.mcstas.org',
+            Flavor.MCXTRACE: 'https://www.mcxtrace.org'
+        }
+        return options[self]
 
 
 __all__ = ["__author__", "__affiliation__", "__version__", "version", "Flavor"]

--- a/src/mccode_antlr/cli/commands.py
+++ b/src/mccode_antlr/cli/commands.py
@@ -45,7 +45,6 @@ def mccode(flavor: Flavor):
     from mccode_antlr.reader.registry import collect_local_registries
     from mccode_antlr.translators.c import CTargetVisitor
     from mccode_antlr.common import Mode
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR, MCXTRACE_GENERATOR
 
     args = mccode_script_parse(str(flavor).lower() + '-antlr')
 
@@ -67,9 +66,8 @@ def mccode(flavor: Flavor):
         # In minimal mode, the component orientations are not resolved -- to speed up the process
         instrument = reader.get_instrument(args.filename, mode=Mode.minimal)
 
-    generator = MCXTRACE_GENERATOR if flavor == Flavor.MCXTRACE else MCSTAS_GENERATOR
     # Construct the object which will translate the Python instrument to C
-    visitor = CTargetVisitor(instrument, generate=generator, config=config, verbose=config['verbose'])
+    visitor = CTargetVisitor(instrument, flavor=flavor, config=config, verbose=config['verbose'])
     # Go through the instrument, finish by writing the output file:
     visitor.save(filename=config['output'])
 

--- a/src/mccode_antlr/compiler/c.py
+++ b/src/mccode_antlr/compiler/c.py
@@ -8,7 +8,7 @@ from mccode_antlr.instr import Instr
 from mccode_antlr.translators.c import CTargetVisitor
 from loguru import logger
 from .check import compiled, gpu_only, mpi_only
-
+from mccode_antlr import Flavor
 
 class CBinaryTarget:
     class Type(Flag):
@@ -84,11 +84,11 @@ class CBinaryTarget:
         return extras
 
 
-def instrument_source(instrument: Instr, generator: dict, config: dict, verbose: bool = None):
+def instrument_source(instrument: Instr, flavor: Flavor, config: dict, verbose: bool = None):
     if verbose is None:
         verbose = config.get('verbose', False)
     # TargetVisitor to uses instrument.registries (and the CTargetVisitor *appends* its LIBC_REGISTRY if necessary)
-    visitor = CTargetVisitor(instrument, generate=generator, config=config, verbose=verbose)
+    visitor = CTargetVisitor(instrument, flavor=flavor, config=config, verbose=verbose)
     # Does the conversion by 'visiting' the instrument, then returns the full string of the generated source code
     return visitor.contents()
 

--- a/src/mccode_antlr/compiler/check.py
+++ b/src/mccode_antlr/compiler/check.py
@@ -25,7 +25,7 @@ def compiles(compiler: str, instr):
     from loguru import logger
     from pathlib import Path
     from tempfile import TemporaryDirectory
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR
+    from mccode_antlr import Flavor
     from .c import (CBinaryTarget, instrument_source,
                     linux_split_flags, windows_split_flags,
                     linux_compile, windows_compile)
@@ -42,7 +42,7 @@ def compiles(compiler: str, instr):
 
     with TemporaryDirectory() as directory:
         binary = Path(directory) / f"output{module_config['ext'].get(str)}"
-        source = instrument_source(instr, generator=MCSTAS_GENERATOR, config=compile_config)
+        source = instrument_source(instr, flavor=Flavor.MCSTAS, config=compile_config)
         compile_func = windows_compile if 'Windows' == system() else linux_compile
         command, result = compile_func(target.compiler, compiler_flags, binary, linker_flags, source)
 

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -562,8 +562,8 @@ def default_registries(flavor: Flavor) -> list[Registry]:
     indicate ${flavor}.paths in the config dictionary
     """
     from mccode_antlr.config import config
-
-    r = [MCXTRACE_REGISTRY if flavor == Flavor.MCXTRACE else MCSTAS_REGISTRY, LIBC_REGISTRY]
+    options = {Flavor.MCSTAS: MCSTAS_REGISTRY, Flavor.MCXTRACE: MCXTRACE_REGISTRY}
+    r = [options[flavor], LIBC_REGISTRY]
 
     if 'paths' not in config[str(flavor).lower()]:
         return r

--- a/src/mccode_antlr/translators/target.py
+++ b/src/mccode_antlr/translators/target.py
@@ -1,10 +1,8 @@
+from loguru import logger
 from io import StringIO
 from ..instr import Instr, Instance
-from ..comp import Comp
-from loguru import logger
+from mccode_antlr import Flavor
 
-MCSTAS_GENERATOR = dict(project=1, name="mcstas", fancy="McStas", url='http://www.mcstas.org')
-MCXTRACE_GENERATOR = dict(project=2, name='mcxtrace', fancy='McXtrace', url='http://www.mcxtrace.org')
 
 # These _should_ be set in a call to, e.g., `mcstas4`,
 # They were previously set in the yacc generated main function
@@ -14,8 +12,8 @@ CONFIG = dict(default_main=True, enable_trace=True, portable=True, include_runti
 
 # Follow the logic of codegen.c(.in) from McCode-3, but make use of visitor semantics for possible alternate runtimes
 class TargetVisitor:
-    def __init__(self, instr: Instr, generate: dict = None, config: dict = None, verbose=False):
-        self.runtime = MCSTAS_GENERATOR if generate is None else generate
+    def __init__(self, instr: Instr, flavor: Flavor = Flavor.MCSTAS, config: dict = None, verbose=False):
+        self.flavor = flavor
         self.config = CONFIG if config is None else config
         self.source = instr
         self.output = None
@@ -40,13 +38,6 @@ class TargetVisitor:
 
     def __post_init__(self):
         pass
-
-    @property
-    def is_mcstas(self):
-        index = self.runtime.get('project')
-        if index != 1 and index != 2:
-            raise RuntimeError(f'Unknown runtime for project index {index}')
-        return index == 1
 
     @property
     def registries(self):

--- a/tests/instr/utils.py
+++ b/tests/instr/utils.py
@@ -1,7 +1,9 @@
-def make_assembler(name: str):
+from mccode_antlr import Flavor
+
+def make_assembler(name: str, flavor: Flavor = Flavor.MCSTAS):
     from mccode_antlr.assembler import Assembler
     from mccode_antlr.reader.registry import default_registries
-    return Assembler(name, registries=default_registries('mcstas'))
+    return Assembler(name, registries=default_registries(flavor))
 
 
 def parse_instr_string(instr_source: str):

--- a/tests/runtime/compiled.py
+++ b/tests/runtime/compiled.py
@@ -55,15 +55,12 @@ def compile_and_run(instr,
                     flavor: Flavor = Flavor.MCSTAS):
     from pathlib import Path
     from tempfile import TemporaryDirectory
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR, MCXTRACE_GENERATOR
     from mccode_antlr.run import mccode_compile, mccode_run_compiled
 
-    generator = MCXTRACE_GENERATOR if flavor == Flavor.MCXTRACE else MCSTAS_GENERATOR
-
-    kwargs = dict(generator=generator, target=target, config=config, dump_source=dump_source)
+    kwargs = dict(target=target, config=config, dump_source=dump_source)
 
     with TemporaryDirectory() as directory:
-        binary, target = mccode_compile(instr, directory, **kwargs)
+        binary, target = mccode_compile(instr, directory, flavor=flavor, **kwargs)
         # The runtime output directory used *can not* exist for McStas/McXtrace to work properly.
         # So find a name inside this directory that doesn't exist (any name should work)
         return mccode_run_compiled(binary, target, Path(directory).joinpath('t'), parameters) if run else (None, None)

--- a/tests/runtime/test_instr.py
+++ b/tests/runtime/test_instr.py
@@ -129,7 +129,7 @@ class TestCompiledInstr(TestCase):
         from mccode_antlr.instr import Instr
         from mccode_antlr.common import ComponentParameter, Expr
         from mccode_antlr.compiler.c import compile_instrument, run_compiled_instrument, CBinaryTarget
-        from mccode_antlr.translators.target import MCSTAS_GENERATOR
+        from mccode_antlr import Flavor
         from mccode_antlr.loader import read_mccode_dat, parse_mcstas_instr
         from tempfile import TemporaryDirectory
         from os import R_OK, access
@@ -187,7 +187,7 @@ class TestCompiledInstr(TestCase):
             expected_binaries = [Path(directory).joinpath(f'{x.name}.out') for x in (instr, before, after)]
             for obj in (instr, before, after):
                 try:
-                    compile_instrument(obj, target, directory, generator=MCSTAS_GENERATOR, config=config)
+                    compile_instrument(obj, target, directory, flavor=Flavor.MCSTAS, config=config)
                 except RuntimeError as e:
                     logger.error(f'Failed to compile instrument: {e}')
                     raise e

--- a/tests/runtime/test_raytrace.py
+++ b/tests/runtime/test_raytrace.py
@@ -26,10 +26,10 @@ class Capturing(list):
 def instrument_translation_prints_funnel(instr):
     import re
     from mccode_antlr.compiler.c import instrument_source
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR
+    from mccode_antlr import Flavor
     # Check that the McStas-parsing of the instrument prints '-DFUNNEL' to STDOUT
     with Capturing() as output:
-        instrument_source(instr, MCSTAS_GENERATOR, {}, False)
+        instrument_source(instr, Flavor.MCSTAS, {}, False)
 
     flags_line = re.compile('^CFLAGS=.*$')
 

--- a/tests/runtime/test_when.py
+++ b/tests/runtime/test_when.py
@@ -30,12 +30,11 @@ def test_when_logical_parses():
 def do_when_op_(checker, op, message):
     from pathlib import Path
     from tempfile import TemporaryDirectory
-    from mccode_antlr.translators.target import MCSTAS_GENERATOR
+    from mccode_antlr import Flavor
     from mccode_antlr.run import mccode_compile, mccode_run_compiled
     from itertools import product
 
-    kwargs = dict(generator=MCSTAS_GENERATOR, target=None, config=None,
-                  dump_source=False)
+    kwargs = dict(target=None, config=None, dump_source=False)
 
     instr = parse_mcstas_instr(
         dedent(f"""DEFINE INSTRUMENT when_equal(int value=0, int check=-1)
@@ -51,7 +50,7 @@ def do_when_op_(checker, op, message):
         """)
     )
     with TemporaryDirectory() as directory:
-        binary, target = mccode_compile(instr, directory, **kwargs)
+        binary, target = mccode_compile(instr, directory, Flavor.MCSTAS, **kwargs)
         for index, (value, check) in enumerate(product((0, 1, 2, 3), (1, 2, 3, 4))):
             path = Path(directory).joinpath(f't{index}')
             result, data = mccode_run_compiled(binary, target, path, f'-n 1 {value=} {check=}')

--- a/tests/test_component_vector_parameter.py
+++ b/tests/test_component_vector_parameter.py
@@ -62,7 +62,7 @@ class ComponentVectorParameterTestCase(unittest.TestCase):
 
     def _compile_and_run(self, instr, parameters):
         from mccode_antlr.compiler.c import compile_instrument, CBinaryTarget, run_compiled_instrument
-        from mccode_antlr.translators.target import MCSTAS_GENERATOR
+        from mccode_antlr import Flavor
         from mccode_antlr.config import config as module_config
         from tempfile import TemporaryDirectory
         from os import R_OK, access
@@ -74,7 +74,7 @@ class ComponentVectorParameterTestCase(unittest.TestCase):
 
         with TemporaryDirectory() as directory:
             try:
-                compile_instrument(instr, target, directory, generator=MCSTAS_GENERATOR, config=config, dump_source=True)
+                compile_instrument(instr, target, directory, flavor=Flavor.MCSTAS, config=config, dump_source=True)
             except RuntimeError as e:
                 raise e
             binary = Path(directory).joinpath(f'{instr.name}{module_config["ext"].get(str)}')

--- a/tests/test_local_registry_collection.py
+++ b/tests/test_local_registry_collection.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 from pathlib import Path
+from mccode_antlr import Flavor
 import mccode_antlr.config
 
 MCKEY = 'MCCODEANTLR_MCSTAS__PATHS'
@@ -35,22 +36,22 @@ class TestLocalRegistryCollection(TestCase):
         import os
         from unittest.mock import patch
         with patch.dict(os.environ, {MCKEY: self.temps[0].as_posix()}):
-            self.assertPaths('mcstas', self.temps[0:1])
+            self.assertPaths(Flavor.MCSTAS, self.temps[0:1])
 
     def test_mcxtrace_environment_variable_single(self):
         import os
         from unittest.mock import patch
         with patch.dict(os.environ, {MXKEY: self.temps[1].as_posix()}):
-            self.assertPaths('mcxtrace', self.temps[1:2])
+            self.assertPaths(Flavor.MCXTRACE, self.temps[1:2])
 
     def test_mcstas_environment_variable_multi(self):
         import os
         from unittest.mock import patch
         with patch.dict(os.environ, {MCKEY: ' '.join(p.as_posix() for p in self.temps)}):
-            self.assertPaths('mcstas', self.temps[0:2])
+            self.assertPaths(Flavor.MCSTAS, self.temps[0:2])
 
     def test_mcxtrace_environment_variable_multi(self):
         import os
         from unittest.mock import patch
         with patch.dict(os.environ, {MXKEY: ' '.join(p.as_posix() for p in self.temps)}):
-            self.assertPaths('mcxtrace', self.temps[0:2])
+            self.assertPaths(Flavor.MCXTRACE, self.temps[0:2])


### PR DESCRIPTION
Fixes #139 by removing `Flavor` ternary operators in favor of the dictionary method described there.

All changes were made in the following commit:

#### *[Ref]* fold 'generator' information into Flavor enum
- The `TargetVisitor` translator needs information about what specialization of McCode is being generated. This special information was held in a 'generator' dictionary with module-global defaults set for McStas and McXtrace (`MCSTAS_GENERATOR`, `MCXTRACE_GENERATOR`, respectively)/
- All information needed by the generator dictionary except the specialization URL could already be obtained from `Flavor` (with the 'project' id made easier to obtain by promoting `Flavor `to an `IntEnum`). So adding a `url()` method to `Flavor` allows dropping the module-global dictionaries.
- Making this change, a number of string-as-`Flavor` errors were corrected. And a `is_mcstas` bool was replaced by hopefully more-robust `Flavor` use.