### PR TITLE
Compilation flag fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = ["gputil==1.4.0", 'pytest']
 hdf5 = ["h5py>=3.11.0"]
+mcpl = ["mcpl>=2.2.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/mccode-dev/mccode-antlr"

--- a/src/mccode_antlr/__init__.py
+++ b/src/mccode_antlr/__init__.py
@@ -13,11 +13,16 @@ class Flavor(IntEnum):
 
     Enumerated _values_ follow the McCode _project_ number.
     """
+    BASE=0
     MCSTAS=1
     MCXTRACE=2
 
     def __str__(self):
-        options = {Flavor.MCSTAS: 'McStas', Flavor.MCXTRACE: 'McXTrace'}
+        options = {
+            Flavor.BASE: 'base',
+            Flavor.MCSTAS: 'McStas',
+            Flavor.MCXTRACE: 'McXTrace'
+        }
         return options[self]
 
     def url(self) -> str:

--- a/src/mccode_antlr/cli/commands.py
+++ b/src/mccode_antlr/cli/commands.py
@@ -42,9 +42,8 @@ def mccode_script_parse(prog: str):
 
 def mccode(flavor: Flavor):
     args = mccode_script_parse(str(flavor).lower() + '-antlr')
-    from mccode_antlr.reader import Reader # Causes creation of .cache and .config folders
-    from mccode_antlr.reader.registry import collect_local_registries # Causes creation of .cache and .config folders
-    from mccode_antlr.translators.c import CTargetVisitor  # Causes creation of .cache and .config folders
+    from mccode_antlr.reader import Reader, collect_local_registries
+    from mccode_antlr.translators.c import CTargetVisitor
     from mccode_antlr.common import Mode
 
     config = dict(default_main=args.main,

--- a/src/mccode_antlr/cli/commands.py
+++ b/src/mccode_antlr/cli/commands.py
@@ -41,12 +41,11 @@ def mccode_script_parse(prog: str):
 
 
 def mccode(flavor: Flavor):
-    from mccode_antlr.reader import Reader
-    from mccode_antlr.reader.registry import collect_local_registries
-    from mccode_antlr.translators.c import CTargetVisitor
-    from mccode_antlr.common import Mode
-
     args = mccode_script_parse(str(flavor).lower() + '-antlr')
+    from mccode_antlr.reader import Reader # Causes creation of .cache and .config folders
+    from mccode_antlr.reader.registry import collect_local_registries # Causes creation of .cache and .config folders
+    from mccode_antlr.translators.c import CTargetVisitor  # Causes creation of .cache and .config folders
+    from mccode_antlr.common import Mode
 
     config = dict(default_main=args.main,
                   enable_trace=args.trace,

--- a/src/mccode_antlr/cli/management.py
+++ b/src/mccode_antlr/cli/management.py
@@ -94,7 +94,7 @@ def add_config_management_parser(modes):
 
 def cache_path():
     from pooch import os_cache
-    return os_cache(f'mccode_antlr')
+    return os_cache(f'mccodeantlr')
 
 
 def cache_remove(name, version, force):

--- a/src/mccode_antlr/config/fallback.py
+++ b/src/mccode_antlr/config/fallback.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from collections.abc import Callable
+from confuse import LazyConfig, Subview
+from loguru import logger
+
+def config_fallback(
+        cfg: LazyConfig | Subview,
+        key: str,
+        method: str | None = None,
+        prog: str | None = None,
+        failsafe: Callable[[str], str] | None = None,
+        store: bool = True,
+):
+    import platform
+    from subprocess import getstatusoutput, run
+    method = method or 'get'
+    prog = prog or f'{key}-config --show buildflags'
+    if failsafe is None:
+        failsafe = lambda x: f'-l{x}'
+    if key in cfg:
+        return getattr(cfg[key], method)()
+
+    # If the specified program exists
+    checker = {'Windows': 'where'}.get(platform.system(), 'which')
+    status, output = getstatusoutput(f'{checker} {prog.split()[0]}')
+    if 0 == status:
+        # Try running it
+        status, output = getstatusoutput(prog)
+    # If it failed, fallback again to the failsafe result
+    if status:
+        output = failsafe(key)
+        logger.warning(f'Unable to find {key} or use {prog}, defaulting to {output}')
+
+    # No matter what, if we got this far store the result in the working config cache
+    # to avoid needing to re-run any possibly-expensive function.
+    # This is predicated on the idea that only one possible function would be called
+    if store:
+        cfg[key] = output
+    return output

--- a/src/mccode_antlr/reader/__init__.py
+++ b/src/mccode_antlr/reader/__init__.py
@@ -1,6 +1,10 @@
 from .reader import Reader
-from .registry import (Registry, LocalRegistry, RemoteRegistry, ModuleRemoteRegistry, GitHubRegistry,
-                       MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY)
+from .registry import (
+    Registry,
+    LocalRegistry, RemoteRegistry, ModuleRemoteRegistry, GitHubRegistry,
+    InMemoryRegistry,
+    collect_local_registries, default_registries, ensure_registries
+)
 
 __all__ = [
     'Reader',
@@ -9,7 +13,8 @@ __all__ = [
     'RemoteRegistry',
     'ModuleRemoteRegistry',
     'GitHubRegistry',
-    'MCSTAS_REGISTRY',
-    'MCXTRACE_REGISTRY',
-    'LIBC_REGISTRY',
+    'InMemoryRegistry',
+    collect_local_registries,
+    default_registries,
+    ensure_registries,
 ]

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -241,7 +241,7 @@ class GitHubRegistry(RemoteRegistry):
             registry = f'{registry}/raw/{self.version}/'
 
         base_url = f'{self.url}/raw/{self.version}/'
-        cache_path = pooch.os_cache(f'mccode_antlr/{self.name}')
+        cache_path = pooch.os_cache(f'mccodeantlr/{self.name}')
         registry_file = self.filename or 'pooch-registry.txt'
         registry_file_path = cache_path.joinpath(self.version, registry_file)
         if registry_file_path.exists() and registry_file_path.is_file() and access(registry_file_path, R_OK):
@@ -500,6 +500,8 @@ def _mccode_pooch_registries(flavor: Flavor):
         return list(dict.fromkeys(ex.findall(res)))
 
     def source_registry_tag():
+        """This causes the confuse config directory to be created, so could fail
+        on read-only systems."""
         from mccode_antlr.config import config
         requested_tag = config['mccode_pooch']['tag'].as_str_expanded()
         registry_url = config['mccode_pooch']['registry'].as_str_expanded()

--- a/src/mccode_antlr/translators/c.py
+++ b/src/mccode_antlr/translators/c.py
@@ -1,9 +1,9 @@
 """Translates a McComp instrument from its intermediate form to a C runtime source file."""
 from loguru import logger
 from dataclasses import dataclass
-from ..reader import LIBC_REGISTRY
 from .target import TargetVisitor
 from .c_listener import extract_c_declared_variables
+from mccode_antlr import Flavor
 
 
 @dataclass
@@ -231,10 +231,9 @@ class CTargetVisitor(TargetVisitor, target_language='c'):
         """
         # Make sure the registry list contains the C library registry, so that we can find and include files
         from packaging.version import Version
-        from ..reader.registry import ordered_registries
-        if not any(reg == LIBC_REGISTRY for reg in self.registries):
-            self.source.registries += (LIBC_REGISTRY, )
-        self.source.registries = tuple(ordered_registries(list(self.source.registries)))
+        from ..reader.registry import ordered_registries, ensure_registries
+        # make sure that the libc registry is present before sorting:
+        self.source.registries = tuple(ordered_registries(ensure_registries(Flavor.BASE, list(self.source.registries))))
 
         # Check that the LIBC registry is not too old for current translation
         for reg in self.source.registries:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,4 +1,7 @@
 def test_mccode_pooch_tags():
-    from mccode_antlr.reader.registry import MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY
-    for reg in (MCSTAS_REGISTRY, MCXTRACE_REGISTRY, LIBC_REGISTRY):
-        assert reg.version != "main"
+    from mccode_antlr import Flavor
+    from mccode_antlr.reader import default_registries
+    for flavor in (Flavor.BASE, Flavor.MCSTAS, Flavor.MCXTRACE,):
+        for reg in default_registries(flavor):
+            assert reg.version != "main"
+


### PR DESCRIPTION
Since fully-fledged `MCPL` and `NCrystal` can be installed from PyPI, it's not difficult to imagine a user might want to use them with `mccode-antlr` with minimal hand-editing of the ``/.config/mccodeantlr/config.yml` file.

This adds a probably-most-often-used 'fallback' method to resolve `@{PROJECT}FLAGS@` McStas/McXtrace `DEPENDENCY` lines via `{project}-config --show buildflags` which both `MCPL` and `NCrystal` support, and are also the only two uses of the double @ escaped configuration keys.

Other minor functionality changes delay creating the `~/.cache/mccodeantlr` and `~/.config/mccodeantlr` folders, by removing the module-global `MCSTAS_REGISTRY`, `MCXTRACE_REGISTRY`, and `LIBC_REGISTRY` and instead accessing them only via `default_registries(flavor: Flavor)`. This required introducing a _new_ flavor, `BASE`, which only needs the common libc registry.