### PR TITLE
[Add] in-file path specification for HDF5 loading

### DIFF
--- a/src/mccode_antlr/io/hdf5.py
+++ b/src/mccode_antlr/io/hdf5.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Union
 from loguru import logger
@@ -477,7 +479,21 @@ def save_hdf5(obj, filename: Union[str, Path]) -> None:
         HDF5IO.save(file, obj)
 
 
-def load_hdf5(filename: Union[str, Path]):
+def load_hdf5(filename: Union[str, Path], path: str | None = None):
+    """Load all or part of a serialized Instr from a HDF5 file.
+
+    Parameters
+    ----------
+    filename : Union[str, Path]
+        Path to the HDF5 file.
+    path: str or None
+        Location within the file to load, or None to load all.
+
+    Example
+    -------
+    >>> from mccode_antlr.io.hdf5 import load_hdf5
+    >>> instrument_parameters = load_hdf5('instr.h5', 'parameters')
+    """
     import h5py
     with h5py.File(filename, 'r', driver='core', backing_store=False) as file:
-        return HDF5IO.load(file)
+        return HDF5IO.load(file[path] if path else file)

--- a/tests/instr/test_hdf5_comp_reference.py
+++ b/tests/instr/test_hdf5_comp_reference.py
@@ -167,6 +167,21 @@ class SplitHDF5BifrostTestCase(SplitBifrostTestCase):
             save_hdf5(make_truncated_bifrost(), filepath)
             self.bifrost = load_hdf5(filepath)
 
+    def test_load_parameters(self):
+        from mccode_antlr.io import load_hdf5
+        from mccode_antlr.common import InstrumentParameter
+        parameters = load_hdf5(self.td.joinpath('bifrost.h5'), 'parameters')
+        self.assertTrue(isinstance(parameters, tuple))
+        self.assertTrue(all(isinstance(p, InstrumentParameter) for p in parameters))
+
+        expected = [InstrumentParameter.parse(s) for s in (
+            'int pulses = 1', 'power/"MW" = 2', 'source_lambda_min/"angstrom" = 0.75',
+            'source_lambda_max/"angstrom" = 30',)]
+        self.assertEqual(len(parameters), len(expected))
+        self.assertTrue(all(x in expected for x in parameters))
+        self.assertTrue(all(x in parameters for x in expected))
+
+
     def tearDown(self):
         from shutil import rmtree
         rmtree(self.td)


### PR DESCRIPTION
Partially addresses #143 by adding the ability to load just a part of the HDF5 `Instr` representation.
