### PR TITLE
[Fix] issue reconstituting Op/Value objects

### DIFF
--- a/src/mccode_antlr/common/expression.py
+++ b/src/mccode_antlr/common/expression.py
@@ -598,6 +598,11 @@ class Value(Struct):
         if self._shape is None:
             self._shape = ShapeType.vector if not isinstance(self._value, str) and hasattr(self._value, '__len__') else ShapeType.scalar
 
+        for prop, typ in zip(('_data', '_object', '_shape'), (DataType, ObjectType, ShapeType)):
+            if not isinstance(getattr(self, prop), typ):
+                setattr(self, prop, typ(getattr(self, prop)))
+
+
     def __int__(self):
         if self.data_type != DataType.int:
             raise RuntimeError('Non-integer data type Value; round first')
@@ -1389,3 +1394,7 @@ def op_post_init(obj, props: list[str], special: dict):
         # datatype + datatype promotion preserves A+A=A
         obj.data_type = a[0] + b[0]
 
+    # ensure that data_type is a DataType and style is an OpStyle?
+    for prop, typ in (('data_type', DataType), ('style', OpStyle)):
+        if not isinstance(p:=getattr(obj, prop), typ):
+            setattr(obj, prop, typ(p))

--- a/tests/io/test_json.py
+++ b/tests/io/test_json.py
@@ -1,4 +1,14 @@
 from mccode_antlr.io.json import to_json, from_json
+from mccode_antlr.common.expression import Value, Expr
+
+
+def assert_round_trip(obj):
+    json = to_json(obj)
+    ret = from_json(json)
+    assert type(ret) is type(obj)
+    assert ret == obj
+    return ret
+
 
 def test_simple_instr_json():
     from mccode_antlr.loader import parse_mcstas_instr
@@ -9,3 +19,32 @@ def test_simple_instr_json():
     assert type(reconstituted) is type(instr)
     assert instr == reconstituted
 
+
+def assert_scalar_expr_round_trip(value: Value):
+    expr = Expr(value)
+    ret = assert_round_trip(expr)
+    assert len(ret.expr) == 1
+    assert ret.expr[0] == value
+    assert str(expr) == str(ret)
+    assert str(value) == str(ret.expr[0])
+
+
+def test_str_expr_json_round_trip():
+    assert_scalar_expr_round_trip(Value.str('some string'))
+
+
+def test_int_expr_json_round_trip():
+    assert_scalar_expr_round_trip(Value.int(1))
+
+
+def test_float_expr_json_round_trip():
+    assert_scalar_expr_round_trip(Value.float(1))
+
+
+def test_instrument_parameter_json_round_trip():
+    from mccode_antlr.common.parameters import InstrumentParameter
+    ip = InstrumentParameter.parse('int x/"m"=1')
+    ret = assert_round_trip(ip)
+    assert ip.name == ret.name
+    assert ip.value == ret.value
+    assert str(ip) == str(ret)


### PR DESCRIPTION
- Both Op and Value objects use Enum-derived flags to help constrain and identify what they represent. Those flags get serialized to corresponding integer values by msgspec, and they were not correctly turned back into Enum representations on the return trip.
- For some enumerated values this may make _no_ difference, e.g., if they are only used in comparisons.  For Enum derived types that add class or instance methods, not converting back from int _will_ cause an error when code attempts to _use_ any method which is not also a method of int.
- All of the enums used by Value (ObjectType, ShapeType, DataType), define methods. None of them were correctly converted back from integer values in expression.py
- All other enums which might be serialized do not define methods, and also were already reconstituted correctly.
- This commit adds to the __post_init__ methods of Value and Op classes to ensure their enumerated flag values are of the correct type. The mechanism they use to convert back is safe for integer values, and hopefully raises an error if passed an invalid integer or non-integer value.