### PR TITLE
Ensure (re-)init of RNG at top of INITIALIZE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     'loguru>=0.7.2',
     'gitpython>=3.1.43',
     'msgspec>=0.19.0',
+    'packaging',
 ]
 description = "ANTLR4 grammars for McStas and McXtrace"
 readme = "README.md"

--- a/src/mccode_antlr/translators/c_raytrace.py
+++ b/src/mccode_antlr/translators/c_raytrace.py
@@ -123,7 +123,7 @@ def cogen_raytrace(source, ok_to_skip):
                 f'      // GROUP {group.name}: from {fn} [{group.first_id}] to {ln} [{1+lid}]',
                 # Skip over when SCATTERED in the group:
                 f'      if (SCATTERED) _particle->_index = {1+lid}; '
-                '// when SCATTERED in GROUP: reach exit of GROUP after {ln}',
+                f'// when SCATTERED in GROUP: reach exit of GROUP after {ln}',
                 #
             ])
             if index == lid:


### PR DESCRIPTION
( As mentioned in https://github.com/mccode-dev/McCode/pull/2227#issuecomment-3613096573 )

It turns out that any use of the RNG in `INIT` scope would not take a `-s seed ` into account. To change this behaviour, the call to `srandom` has been deferred to top of the `init()` function. I believe this should be enough to achieve the same for `mccode-antlr`? (Assuming that you pick up `mccode_main.c` from upstream?)