### PR TITLE
[Add] component-IR-caching 

### DIFF
--- a/src/mccode_antlr/reader/__init__.py
+++ b/src/mccode_antlr/reader/__init__.py
@@ -1,4 +1,4 @@
-from .reader import Reader
+from .reader import Reader, component_cache
 from .registry import (
     Registry,
     LocalRegistry, RemoteRegistry, ModuleRemoteRegistry, GitHubRegistry,


### PR DESCRIPTION
Adds in-memory and on-disk (JSON) component intermediate representation caching for improved (re)parsing instr files in, e.g., a language server.

## Copilot summary
This pull request introduces a process-level two-tier cache for parsed component files to significantly speed up component loading and reduce redundant parsing. It also improves registry tag resolution performance by caching configuration lookups. The main changes are:

### Component caching improvements

* Added a `_ComponentCache` singleton class in `reader.py` that provides both an in-memory and disk-based JSON cache for parsed `Comp` objects, reducing repeated parsing and improving load times (`component_cache`).
* Updated `add_component` in `Reader` to use the new `component_cache` before running the ANTLR parser, and to store parsed components in the cache after parsing.
* Exposed `component_cache` in the `reader` package's `__init__.py` for external use.

### Registry performance and reliability

* Added `functools.cache` to memoize the `_source_registry_tag` function in `registry.py`, ensuring the resolved registry tag is cached per process and reducing repeated network calls. [[1]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bR4) [[2]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bR564-R573)

These changes should result in faster component loading, improved offline usability, and more efficient registry management.