### PR TITLE
[Fix] HTML representation for Jupyter, Registry round-trip bug

### DIFF
--- a/src/mccode_antlr/common/textwrap.py
+++ b/src/mccode_antlr/common/textwrap.py
@@ -239,7 +239,7 @@ class HTMLWrapper(BaseWrapper):
         return '</details>'
 
     def block(self, name: str, content: str) -> str:
-        return '<br>'.join([self.bold(name) + ' %{' + self.hide(f'<pre>{content}</pre><br>') + '%} '])
+        return f'<details><summary>{self.bold(name)}</summary><pre>{content}</pre></details>'
 
     def line(self, name: str, items: list[str], sep: str = ' ') -> str:
         return ''.join(self.wrap(f'<b>{name}</b> {sep.join(items)}')) + '<br>'
@@ -251,7 +251,7 @@ class HTMLWrapper(BaseWrapper):
         return '<br>'.join('<br>'.join(self.wrap(line)) for line in items)
 
     def metadata_group(self, name: str, mimetype: str, item: str, value: str) -> str:
-        return f'<b>{name}</b> <code>{mimetype}</code> <var>{item}</var>' + ' %{' + self.hide(f'<pre>{value}</pre>') +'%}'
+        return f'<b>{name}</b> <code>{mimetype}</code> <var>{item}</var>' + self.hide(f'<pre>{value}</pre>')
 
     @staticmethod
     def datatype(data_type: str) -> str:
@@ -270,11 +270,11 @@ class HTMLWrapper(BaseWrapper):
 
     @staticmethod
     def start_list(name: str) -> str:
-        return f'<ul> {name}'
+        return f'<details open><summary>{name}</summary><ul>'
 
     @staticmethod
     def end_list(name: str) -> str:
-        return f'</ul> {name}'
+        return '</ul></details>'
 
     @staticmethod
     def start_list_item() -> str:
@@ -312,14 +312,8 @@ class HTMLWrapper(BaseWrapper):
     def br() -> str:
         return '<br>'
 
-    def hide(self, content: str) -> str:
-        from uuid import uuid4
-
-        def span(c, tag, i, cont):
-            return f'<span class="{c}" {tag}="{i}">{cont}</span>'
-
-        if len(content.strip()):
-            uuid = 'g-' + str(uuid4())  # a random UUID that _does not_ start with a 0
-            return span(self.hider, 'data-id', uuid, span(self.hidden, 'id', uuid, content))
-
+    @staticmethod
+    def hide(content: str) -> str:
+        if content.strip():
+            return f'<details><summary>…</summary>{content}</details>'
         return content

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -139,36 +139,13 @@ class Instr(Struct):
         from mccode_antlr.common import TextWrapper
         return self.to_string(TextWrapper())
 
-    def _my_repr_html_(self):
+    def _repr_html_(self):
         from mccode_antlr.common import HTMLWrapper
-        wrapper = HTMLWrapper(hider='hider', hidden='hidden')
+        wrapper = HTMLWrapper()
         output = StringIO()
         self.to_file(output=output, wrapper=wrapper)
         body = output.getvalue()
-        style = """
-        <style> 
-        .hider {cursor: pointer; user-select: none;}
-        .hider::before {content: "...";}
-        .hidden-before::before {display: none;}
-        .hidden {display: none;}
-        .active {display: block;}
-        </style>
-        """
-        script = """
-        <script>
-        var toggler = document.getElementsByClassName("hider");
-        var i;
-        for (i = 0; i < toggler.length; i++) {
-            toggler[i].addEventListener("click", function() {
-                var id = this.getAttribute('data-id');
-                this.parentElement.querySelector(`.hidden[id=${id}]`).classList.toggle("active");
-                this.classList.toggle("hidden-before");
-            });
-        }
-        </script>
-        """
-        html = f'<html><head><title>{self.name}</title>{style}</head><body>{body}{script}</body></html>'
-        return html
+        return f'<div class="mccode-instr">{body}</div>'
 
     def add_component(self, a: Instance):
         if any(x.name == a.name for x in self.components):

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -316,6 +316,13 @@ class GitHubRegistry(RemoteRegistry):
     def registry(self):
         return self._stashed_registry
 
+    def to_file(self, output, wrapper):
+        filename = self.filename or f'{self.name}-registry.txt'
+        items = [self.name, wrapper.url(self.url or ''), self.version or '', filename]
+        if self._stashed_registry:
+            items.append(wrapper.url(self._stashed_registry))
+        print(wrapper.line('Registry:', items), file=output)
+
     def file_contents(self) -> dict[str, str]:
         fc = super().file_contents()
         fc['registry'] = self._stashed_registry or ''
@@ -443,7 +450,7 @@ class InMemoryRegistry(Registry):
         self.priority = priority
 
     def to_file(self, output, wrapper):
-        print(f'InMemoryRegistry<{self.name=},{self.version=},{self.components=},{self.priority=}>', file=output)
+        print(wrapper.line('InMemoryRegistry:', [self.name, f'({len(self.components)} components)']), file=output)
 
     def add(self, name: str, definition: str):
         self.components[name] = definition
@@ -599,17 +606,18 @@ def registry_from_specification(spec: str):
     if len(parts) == 0:
         return None
     elif len(parts) == 1:
-        p1, p2, p3, p4 = parts[0], parts[0], None, None
+        p1, p2, p3, p4, p5 = parts[0], parts[0], None, None, None
     elif len(parts) < 4:
-        p1, p2, p3, p4 = parts[0], parts[1], None if len(parts) < 3 else parts[2], None
+        p1, p2, p3, p4, p5 = parts[0], parts[1], None if len(parts) < 3 else parts[2], None, None
     else:
         p1, p2, p3, p4 = parts[0], parts[1], parts[2], parts[3]
-    print(f"Constructing registry from {p1=} {p2=} {p3=} {p4=}  [{type(p1)=} {type(p2)=} {type(p3)=} {type(p4)=}]")
+        p5 = parts[4] if len(parts) >= 5 else None
     # convert string literals to strings:
     p1 = p1[1:-1] if p1.startswith('"') and p1.endswith('"') else p1
     p2 = p2[1:-1] if p2.startswith('"') and p2.endswith('"') else p2
     p3 = p3[1:-1] if p3 is not None and p3.startswith('"') and p3.endswith('"') else p3
     p4 = p4[1:-1] if p4 is not None and p4.startswith('"') and p4.endswith('"') else p4
+    p5 = p5[1:-1] if p5 is not None and p5.startswith('"') and p5.endswith('"') else p5
 
     if Path(p2).exists() and Path(p2).is_dir():
         return LocalRegistry(p1, str(Path(p2).resolve()))
@@ -622,7 +630,7 @@ def registry_from_specification(spec: str):
         return ModuleRemoteRegistry(p1, p2, Path(p3).resolve().as_posix())
 
     if p4 is not None:
-        return GitHubRegistry(p1, p2, p3, p4)
+        return GitHubRegistry(p1, p2, p3, p4, registry=p5)
 
     return None
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -171,6 +171,61 @@ class TestRegistryToFile:
         parts = spec.split()
         assert parts == ['mylib', 'https://example.com/repo', 'v1.0', 'mylib-registry.txt']
 
+    def test_github_registry_with_separate_registry_url_includes_fifth_field(self, monkeypatch):
+        """GitHubRegistry with a separate registry URL should emit 5 fields."""
+        import mccode_antlr.reader.registry as rm
+        calls = {}
+        def fake_init(self, name, url, version, filename=None, registry=None, priority=0):
+            self.name = name
+            self.url = url
+            self.version = version
+            self.filename = filename or f'{name}-registry.txt'
+            self._stashed_registry = registry if isinstance(registry, str) else None
+            self.pooch = None
+            self.priority = priority
+            calls['registry'] = registry
+        monkeypatch.setattr(rm.GitHubRegistry, '__init__', fake_init)
+        reg = rm.GitHubRegistry('files', 'https://github.com/org/files-repo', 'v2.0',
+                                registry='https://github.com/org/registry-repo')
+        line = self._to_file_str(reg)
+        parts = line[len('Registry:'):].strip().split()
+        assert parts == [
+            'files',
+            'https://github.com/org/files-repo',
+            'v2.0',
+            'files-registry.txt',
+            'https://github.com/org/registry-repo',
+        ]
+
+    def test_github_registry_separate_registry_url_roundtrips(self, monkeypatch):
+        """Round-trip: to_file then registry_from_specification preserves the registry URL."""
+        import mccode_antlr.reader.registry as rm
+        captured = {}
+        def fake_init(self, name, url, version, filename=None, registry=None, priority=0):
+            self.name = name
+            self.url = url
+            self.version = version
+            self.filename = filename or f'{name}-registry.txt'
+            self._stashed_registry = registry if isinstance(registry, str) else None
+            self.pooch = None
+            self.priority = priority
+            captured.update(name=name, url=url, version=version, filename=filename, registry=registry)
+        monkeypatch.setattr(rm.GitHubRegistry, '__init__', fake_init)
+
+        reg = rm.GitHubRegistry('files', 'https://github.com/org/files-repo', 'v2.0',
+                                registry='https://github.com/org/registry-repo')
+        line = self._to_file_str(reg)
+        spec = line[len('Registry:'):].strip()
+
+        # Reset captured so we can record what registry_from_specification passes
+        captured.clear()
+        recovered = rm.registry_from_specification(spec)
+        assert recovered is not None
+        assert captured['name'] == 'files'
+        assert captured['url'] == 'https://github.com/org/files-repo'
+        assert captured['version'] == 'v2.0'
+        assert captured['registry'] == 'https://github.com/org/registry-repo'
+
     def test_local_registry_roundtrips(self, tmp_path):
         import mccode_antlr.reader.registry as rm
         reg = rm.LocalRegistry('mylib', str(tmp_path))


### PR DESCRIPTION
This pull request modernizes the HTML formatting and hiding logic in the `textwrap` utilities, simplifies the HTML representation for instrument objects, and enhances registry handling to support a separate registry URL (fifth field) for GitHub registries. It also adds comprehensive tests for these new registry features.

**HTML formatting and hiding improvements:**

* Replaces custom `<span>`-based hiding logic with `<details><summary>…</summary>...</details>` for collapsible sections in `TextWrapper.hide`, `block`, `metadata_group`, and list-related methods, making the HTML output simpler and more standard-compliant. [[1]](diffhunk://#diff-ba185edb61a68536b0b219aa89bb1d8c951b2fa7151e370f4ad34c4f6b9515adL242-R242) [[2]](diffhunk://#diff-ba185edb61a68536b0b219aa89bb1d8c951b2fa7151e370f4ad34c4f6b9515adL254-R254) [[3]](diffhunk://#diff-ba185edb61a68536b0b219aa89bb1d8c951b2fa7151e370f4ad34c4f6b9515adL273-R277) [[4]](diffhunk://#diff-ba185edb61a68536b0b219aa89bb1d8c951b2fa7151e370f4ad34c4f6b9515adL315-R318)
* Simplifies the HTML output for instrument objects by removing custom CSS/JS for hiding and using a `<div class="mccode-instr">` wrapper.

**Registry handling enhancements:**

* Updates `GitHubRegistry` and related functions to support an optional fifth field for a separate registry URL, both in serialization (`to_file`) and parsing (`registry_from_specification`). [[1]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bR319-R325) [[2]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL602-R620) [[3]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL625-R633)
* Adjusts `InMemoryRegistry.to_file` to provide more concise output using the new `wrapper.line` formatting.

**Testing improvements:**

* Adds tests to ensure that GitHub registries with a separate registry URL correctly serialize and round-trip through `registry_from_specification`.