### PR TITLE
Fix directory handling as string instead of Path

### DIFF
--- a/src/mccode_antlr/run/runner.py
+++ b/src/mccode_antlr/run/runner.py
@@ -202,6 +202,8 @@ def mccode_run_scan(name: str, binary, target, parameters, directory, grid: bool
     if directory is None:
         from datetime import datetime
         directory = Path(f'{name}{datetime.now().strftime("%Y%m%d_%H%M%S")}')
+    elif not isinstance(directory, Path):
+        directory = Path(directory)
 
     # if there is only one point, we don't need to scan
     if n_pts > 1:


### PR DESCRIPTION
This pull request makes a minor improvement to the `mccode_run_scan` function in `runner.py` by ensuring that the `directory` parameter is always a `Path` object, even if a string is passed in.

* Ensured that the `directory` parameter is converted to a `Path` object if it is not already, improving consistency