### PR TITLE
[Add] STDOUT to simple_compiler_check for easier debugging

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -1,16 +1,10 @@
-name: Pip
+name: Upstream
 
 on:
   workflow_dispatch:
-  pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    - cron: '30 3 * * 1'
 
-env:
-  # Pin the McCode version whose component and library files are used in tests.
-  # Bump this when a new McCode release should be adopted.
-  MCCODE_VERSION: v3.5.31
 
 jobs:
   build:
@@ -20,7 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        tag: ["v3.5.31", "v3.6.21", "latest"]
+        python-version: ["3.13"]
         strategy: [".", ".[test,hdf5,mcpl]"]
 
     steps:
@@ -69,13 +64,13 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ${{ steps.pooch-cache-dir.outputs.path }}
-        key: pooch-${{ runner.os }}-${{ env.MCCODE_VERSION }}
+        key: pooch-${{ runner.os }}-${{ matrix.tag }}
 
     - name: Pre-populate pooch cache
-      if: steps.cache-pooch.outputs.cache-hit != 'true'
-      run: mccode-antlr cache populate --tag ${{ env.MCCODE_VERSION }}
+      if: (steps.cache-pooch.outputs.cache-hit != 'true') || (matrix.tag == 'latest')
+      run: mccode-antlr cache populate --tag ${{ matrix.tag }}
 
     - name: Test
       env:
-        MCCODEANTLR_MCCODE_POOCH__TAG: ${{ env.MCCODE_VERSION }}
+        MCCODEANTLR_MCCODE_POOCH__TAG: ${{ matrix.tag }}
       run: python -m pytest -v -s

--- a/src/mccode_antlr/cli/cache.py
+++ b/src/mccode_antlr/cli/cache.py
@@ -167,15 +167,19 @@ def cache_populate(tag: str | None, from_path: str | None, clone_url: str, flavo
     if flavor and flavor.lower() != 'both':
         resolved_flavor = Flavor[flavor.upper()]
 
-    # Resolve the tag to use (default: currently-configured version)
-    if tag is None:
+    # Resolve the tag to use.
+    # - no --tag      -> currently configured/effective registry tag
+    # - --tag latest  -> resolve to newest real version tag
+    if tag is None or tag.lower() == 'latest':
         from mccode_antlr.reader.registry import _source_registry_tag
+        if tag is not None:
+            os.environ['MCCODEANTLR_MCCODE_POOCH__TAG'] = tag
+        _source_registry_tag.cache_clear()
         _, _, version = _source_registry_tag()
         tag = f'v{version}'
 
-    # Ensure the environment variable is set so _source_registry_tag() resolves
-    # to the requested tag for *this* process.
-    os.environ.setdefault('MCCODEANTLR_MCCODE_POOCH__TAG', tag)
+    # Ensure the environment variable matches the resolved concrete tag for this process.
+    os.environ['MCCODEANTLR_MCCODE_POOCH__TAG'] = tag
 
     print(f"Populating pooch caches for McCode {tag} …", flush=True)
 
@@ -464,7 +468,7 @@ def add_cache_management_parser(modes):
     )
     p.add_argument(
         '--tag', default=None,
-        help='McCode version tag (e.g. v3.5.31); defaults to the currently-configured version',
+        help='McCode version tag (e.g. v3.5.31, latest); defaults to the currently-configured version',
     )
     p.add_argument(
         '--from-path', dest='from_path', default=None, metavar='PATH',

--- a/src/mccode_antlr/compiler/check.py
+++ b/src/mccode_antlr/compiler/check.py
@@ -35,6 +35,10 @@ def compiles(compiler: str, instr):
                     linux_compile, windows_compile)
     from ..config import config as module_config
 
+    def _rs(label, res):
+        msg = res.decode(errors='replace') if isinstance(res, bytes) else str(res)
+        return f'{label}:\n{msg}'
+
     target = CBinaryTarget(mpi='mpi' in compiler, acc=compiler == 'acc', count=1, nexus=False)
 
     compile_config = dict(default_main=True, enable_trace=False, portable=False,
@@ -51,8 +55,7 @@ def compiles(compiler: str, instr):
         command, result = compile_func(target.compiler, compiler_flags, binary, linker_flags, source)
 
         if result.returncode:
-            stderr = result.stderr.decode(errors='replace').strip() if isinstance(result.stderr, bytes) else str(result.stderr).strip()
-            raise RuntimeError(f"C compiler exited with code {result.returncode}: {stderr}")
+            raise RuntimeError(f"C compiler exited with code {result.returncode}:\n{_rs('STDERR', result.stderr)}\n{_rs('STDOUT', result.stdout)}")
         if not binary.exists() or not binary.is_file() or not access(binary, R_OK):
             raise RuntimeError(f"Compilation produced no executable; check that {target.compiler} works")
 

--- a/tests/runtime/test_when.py
+++ b/tests/runtime/test_when.py
@@ -63,10 +63,12 @@ def do_when_op_(checker, op, message):
                 assert ex == ln
 
 
+@compiled_test
 def test_when_equal_parses():
     do_when_op_(lambda x, y: x == y, '==', 'equal')
 
 
+@compiled_test
 def test_when_not_equal_parses():
     do_when_op_(lambda x, y: x != y, '!=', 'unequal')
 

--- a/tests/test_cli_management.py
+++ b/tests/test_cli_management.py
@@ -399,6 +399,48 @@ class TestCacheManagement:
 
         assert not version_path.exists()
 
+    def test_cache_populate_resolves_latest_to_versioned_tag(self, monkeypatch, tmp_path):
+        """cache populate --tag latest should resolve to the newest real v* tag."""
+        import os
+        from packaging.version import Version
+        import mccode_antlr.cli.cache as cache_module
+        import mccode_antlr.reader.registry as registry_module
+
+        class FakeSourceRegistryTag:
+            def __init__(self):
+                self.cleared = False
+
+            def cache_clear(self):
+                self.cleared = True
+
+            def __call__(self):
+                return 'https://example/source', 'https://example/registry', Version('9.9.1')
+
+        fake_source_registry_tag = FakeSourceRegistryTag()
+        monkeypatch.setattr(registry_module, '_source_registry_tag', fake_source_registry_tag)
+
+        captured = {}
+
+        def fake_populate_from_clone(clone, tag, flavor=None):
+            captured['clone'] = clone
+            captured['tag'] = tag
+            captured['flavor'] = flavor
+            return 0, 0
+
+        monkeypatch.setattr(cache_module, 'populate_from_clone', fake_populate_from_clone)
+
+        cache_module.cache_populate(
+            tag='latest',
+            from_path=str(tmp_path),
+            clone_url='https://example.invalid/McCode.git',
+            flavor='both',
+        )
+
+        assert fake_source_registry_tag.cleared is True
+        assert captured['clone'] == tmp_path.resolve()
+        assert captured['tag'] == 'v9.9.1'
+        assert os.environ['MCCODEANTLR_MCCODE_POOCH__TAG'] == 'v9.9.1'
+
 
 class TestParserFunctions:
     """Test the argument parser creation functions."""
@@ -618,4 +660,3 @@ class TestCacheIR:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
-

--- a/tests/test_config_unset_issue.py
+++ b/tests/test_config_unset_issue.py
@@ -45,11 +45,11 @@ def test_config_unset_preserves_keys():
 
         # Check if other keys are preserved
         print("\nChecking preserved keys:")
-        print(f"  compiler.cc: {'✓' if 'cc' in saved_config.get('compiler', {}) else '✗ MISSING'}")
-        print(f"  compiler.flags: {'✓' if 'flags' in saved_config.get('compiler', {}) else '✗ MISSING'}")
-        print(f"  compiler.debug: {'✗ REMOVED' if 'debug' not in saved_config.get('compiler', {}) else '✓ (should be removed)'}")
-        print(f"  runtime.threads: {'✓' if 'threads' in saved_config.get('runtime', {}) else '✗ MISSING'}")
-        print(f"  runtime.verbose: {'✓' if 'verbose' in saved_config.get('runtime', {}) else '✗ MISSING'}")
+        print(f"  compiler.cc: {'OK' if 'cc' in saved_config.get('compiler', {}) else 'x MISSING'}")
+        print(f"  compiler.flags: {'OK' if 'flags' in saved_config.get('compiler', {}) else 'x MISSING'}")
+        print(f"  compiler.debug: {'x REMOVED' if 'debug' not in saved_config.get('compiler', {}) else 'OK (should be removed)'}")
+        print(f"  runtime.threads: {'OK' if 'threads' in saved_config.get('runtime', {}) else 'x MISSING'}")
+        print(f"  runtime.verbose: {'OK' if 'verbose' in saved_config.get('runtime', {}) else 'x MISSING'}")
 
         # Verify the expected behavior
         assert 'compiler' in saved_config, "compiler section missing!"
@@ -103,10 +103,10 @@ def test_config_unset_entire_section():
 
 if __name__ == '__main__':
     test_config_unset_preserves_keys()
-    print("\n✅ Test 1 passed!")
+    print("\n Test 1 passed!")
 
     test_config_unset_entire_section()
-    print("\n✅ Test 2 passed!")
+    print("\n Test 2 passed!")
 
     print("\n" + "="*60)
     print("All tests passed!")

--- a/tests/test_nested_key_issue.py
+++ b/tests/test_nested_key_issue.py
@@ -44,10 +44,10 @@ def test_nested_key_save_issue():
 
         # Check if all keys are preserved
         print("\nChecking preserved keys:")
-        print(f"  compiler.cc: {'✓' if 'cc' in saved_config.get('compiler', {}) else '✗ MISSING'}")
-        print(f"  compiler.flags: {'✓' if 'flags' in saved_config.get('compiler', {}) else '✗ MISSING'}")
-        print(f"  compiler.debug: {'✓' if 'debug' in saved_config.get('compiler', {}) else '✗ MISSING'}")
-        print(f"  runtime.threads: {'✓' if 'threads' in saved_config.get('runtime', {}) else '✗ MISSING'}")
+        print(f"  compiler.cc: {'OK' if 'cc' in saved_config.get('compiler', {}) else 'x MISSING'}")
+        print(f"  compiler.flags: {'OK' if 'flags' in saved_config.get('compiler', {}) else 'x MISSING'}")
+        print(f"  compiler.debug: {'OK' if 'debug' in saved_config.get('compiler', {}) else 'x MISSING'}")
+        print(f"  runtime.threads: {'OK' if 'threads' in saved_config.get('runtime', {}) else 'x MISSING'}")
 
         # Verify the issue
         assert 'compiler' in saved_config, "compiler section missing!"
@@ -59,5 +59,5 @@ def test_nested_key_save_issue():
 
 if __name__ == '__main__':
     test_nested_key_save_issue()
-    print("\n✅ Test passed!")
+    print("\nOK Test passed!")
 


### PR DESCRIPTION
Also fixes two tests not marked as `compiled`.

CI workflows now use the `pytest` `-s` (`--capture=no`) flag to ensure that any skipped-test logging messages are surfaced.

A new workflow will run weekly to check for failures caused by new McCode repository version tags.