### PR TITLE
[Ref] ensure_registries merge by registry name

### DIFF
--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -826,9 +826,43 @@ def default_registries(flavor: Flavor) -> list[Registry]:
     return r + v
 
 
+def _registry_signature(reg: Registry) -> dict[str, str | None]:
+    signature: dict[str, str | None] = {
+        'type': type(reg).__name__,
+        'name': reg.name,
+        'version': reg.version,
+    }
+    if isinstance(reg, LocalRegistry):
+        signature['root'] = reg.root.as_posix()
+    else:
+        signature['url'] = getattr(reg, 'url', None)
+        signature['filename'] = getattr(reg, 'filename', None)
+        if isinstance(reg, GitHubRegistry):
+            signature['registry'] = reg.registry
+    return signature
+
 
 def ensure_registries(flavor: Flavor, have: list[Registry] | None):
     needed = default_registries(flavor)
     if have is None or len(have) == 0:
         return needed
-    return list(set(needed) | set(have))
+
+    merged: dict[str, Registry] = {}
+    order: list[str] = []
+    for reg in needed + have:
+        existing = merged.get(reg.name)
+        if existing is None:
+            merged[reg.name] = reg
+            order.append(reg.name)
+            continue
+
+        existing_sig = _registry_signature(existing)
+        new_sig = _registry_signature(reg)
+        if existing_sig != new_sig:
+            logger.warning(
+                f"Registry {reg.name!r} was specified more than once; using the file entry "
+                f"{new_sig} instead of the configured entry {existing_sig}."
+            )
+        merged[reg.name] = reg
+
+    return [merged[name] for name in order]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -303,3 +303,68 @@ class TestRegistriesFromInstrHeader:
         source = f'\n\n/* Instrument foo\nRegistry: mylib {tmp_path.as_posix()}\n*/\n'
         regs = registries_from_instr_header(source)
         assert len(regs) == 1
+
+
+# ---------------------------------------------------------------------------
+# ensure_registries — default/file merge behavior
+# ---------------------------------------------------------------------------
+
+class TestEnsureRegistries:
+    def test_file_registry_overrides_default_and_warns_on_version_change(self, monkeypatch):
+        import mccode_antlr.reader.registry as rm
+
+        default = rm.RemoteRegistry(
+            'libc',
+            'https://example.com/default',
+            'v9',
+            'libc-registry.txt',
+        )
+        file_reg = rm.RemoteRegistry(
+            'libc',
+            'https://example.com/file',
+            'v8',
+            'libc-registry.txt',
+        )
+
+        warnings = []
+
+        class DummyLogger:
+            def warning(self, msg):
+                warnings.append(msg)
+
+        monkeypatch.setattr(rm, 'default_registries', lambda flavor: [default])
+        monkeypatch.setattr(rm, 'logger', DummyLogger())
+
+        merged = rm.ensure_registries(rm.Flavor.BASE, [file_reg])
+
+        assert len(merged) == 1
+        assert merged[0] is file_reg
+        assert len(warnings) == 1
+        assert 'libc' in warnings[0]
+        assert 'v9' in warnings[0]
+        assert 'v8' in warnings[0]
+        assert 'https://example.com/default' in warnings[0]
+        assert 'https://example.com/file' in warnings[0]
+
+    def test_file_registry_overrides_default_and_warns_on_root_change(self, monkeypatch, tmp_path):
+        import mccode_antlr.reader.registry as rm
+
+        default = rm.LocalRegistry('components', str(tmp_path / 'default'))
+        file_reg = rm.LocalRegistry('components', str(tmp_path / 'file'))
+
+        warnings = []
+
+        class DummyLogger:
+            def warning(self, msg):
+                warnings.append(msg)
+
+        monkeypatch.setattr(rm, 'default_registries', lambda flavor: [default])
+        monkeypatch.setattr(rm, 'logger', DummyLogger())
+
+        merged = rm.ensure_registries(rm.Flavor.BASE, [file_reg])
+
+        assert len(merged) == 1
+        assert merged[0] is file_reg
+        assert len(warnings) == 1
+        assert str(tmp_path / 'default') in warnings[0]
+        assert str(tmp_path / 'file') in warnings[0]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -366,5 +366,5 @@ class TestEnsureRegistries:
         assert len(merged) == 1
         assert merged[0] is file_reg
         assert len(warnings) == 1
-        assert str(tmp_path / 'default') in warnings[0]
-        assert str(tmp_path / 'file') in warnings[0]
+        assert (tmp_path / 'default').as_posix() in warnings[0]
+        assert (tmp_path / 'file').as_posix() in warnings[0]


### PR DESCRIPTION
This pull request improves how registry configurations are merged and validated, ensuring that file-specified registries properly override defaults and that users are warned when there are conflicts. The changes introduce a more robust merging strategy and add comprehensive tests for this behavior.

### Registry merging logic improvements

* Added a `_registry_signature` helper function in `registry.py` to generate comparable signatures for different registry types, enabling more accurate detection of conflicts between registry entries.
* Updated the `ensure_registries` function to merge default and file-specified registries by name, preferring the file entry and issuing a warning when a conflict is detected (e.g., differences in version, URL, or root). The function now maintains registry order and logs detailed warnings about the differences.

### Testing enhancements

* Added a new `TestEnsureRegistries` class in `test_registry.py` with tests to verify that file registries override defaults and that warnings are correctly issued when there are differences in registry properties such as version or root. These tests use monkeypatching to control defaults and capture warnings.