### PR TITLE
Fix typo: conetents -> contents (issue #255)

### DIFF
--- a/tests/test_c_include_replacement.py
+++ b/tests/test_c_include_replacement.py
@@ -10,7 +10,7 @@ def test_codegen_header_replacement_rewrites_bad_include(monkeypatch):
             return name == "windirent.h"
 
         # Keep method name aligned with current translator implementation.
-        def conetents(self, name):
+        def contents(self, name):
             return "/* vendored windirent */\nint dirent_dummy;\n"
 
     monkeypatch.setattr(reader_mod, "codegen_registries", lambda: [DummyCodegenRegistry()])


### PR DESCRIPTION
Fix typo in test mock: `def conetents` → `def contents` to match the actual method name `reg.contents(filename)`. Fixes #255.