### PR TITLE
Remove deprecated tag versions from workflow

### DIFF
--- a/.github/workflows/upstream.yml
+++ b/.github/workflows/upstream.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-latest]
-        tag: ["v3.5.31", "v3.6.21", "latest"]
+        tag: ["v3.5.31", "latest"]
         python-version: ["3.13"]
         strategy: [".", ".[test,hdf5,mcpl]"]
 


### PR DESCRIPTION
McCode v3.6.21 includes "dirent.h" even on Windows, with the Conda packages relying on a single-header Conda package to provide the include resolution. This setup is not supported here without manual installation of the same header, so it should not be tested in a workflow.