### PR TITLE
Add CLI convert action including Instr to python

### DIFF
--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -178,6 +178,7 @@ mccode-antlr SUBCOMMAND [OPTIONS]
 | `cache` | Manage the component file cache |
 | `config` | Manage the mccode-antlr configuration |
 | `datafile` | Work with McCode data files (Bragg tables, SQW files, …) |
+| `convert` | Convert instrument descriptions between `.instr` and `.json` |
 
 ---
 
@@ -234,3 +235,22 @@ mccode-antlr SUBCOMMAND [OPTIONS]
 | `get` | Download a data file and copy it to a directory |
 
 Run `mccode-antlr SUBCOMMAND ACTION -h` for the full option list of any individual action.
+
+---
+
+#### `mccode-antlr convert`
+
+Convert between serialized instrument formats.
+
+```bash
+mccode-antlr convert INPUT [-o OUTPUT] [--to {python,json,instr}] [--flavor {mcstas,mcxtrace}] [-I DIR ...]
+```
+
+| Flag | Description |
+|---|---|
+| `INPUT` | Input file (`.instr` or `.json`) |
+| `-o`, `--output` | Output file path (if omitted, inferred from target/input) |
+| `--to` | Target format (`json` and `instr` implemented in PR1; `python` planned) |
+| `--flavor` | Flavor used when reading `.instr` input (`mcstas` default) |
+| `-I`, `--search-dir` | Extra component search directory when reading `.instr` |
+| `--optimize` | Reserved for future Python code-generation optimization |

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -178,7 +178,7 @@ mccode-antlr SUBCOMMAND [OPTIONS]
 | `cache` | Manage the component file cache |
 | `config` | Manage the mccode-antlr configuration |
 | `datafile` | Work with McCode data files (Bragg tables, SQW files, …) |
-| `convert` | Convert instrument descriptions between `.instr` and `.json` |
+| `convert` | Convert instrument descriptions between `.instr`, `.json`, and Python assembler scripts |
 
 ---
 
@@ -240,7 +240,7 @@ Run `mccode-antlr SUBCOMMAND ACTION -h` for the full option list of any individu
 
 #### `mccode-antlr convert`
 
-Convert between serialized instrument formats.
+Convert between serialized instrument formats and generated Python assembler scripts.
 
 ```bash
 mccode-antlr convert INPUT [-o OUTPUT] [--to {python,json,instr}] [--flavor {mcstas,mcxtrace}] [-I DIR ...]
@@ -250,7 +250,7 @@ mccode-antlr convert INPUT [-o OUTPUT] [--to {python,json,instr}] [--flavor {mcs
 |---|---|
 | `INPUT` | Input file (`.instr` or `.json`) |
 | `-o`, `--output` | Output file path (if omitted, inferred from target/input) |
-| `--to` | Target format (`json` and `instr` implemented in PR1; `python` planned) |
+| `--to` | Target format (`python`, `json`, or `instr`) |
 | `--flavor` | Flavor used when reading `.instr` input (`mcstas` default) |
 | `-I`, `--search-dir` | Extra component search directory when reading `.instr` |
-| `--optimize` | Reserved for future Python code-generation optimization |
+| `--optimize` | Reserved for future optimized Python code-generation mode |

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -253,4 +253,4 @@ mccode-antlr convert INPUT [-o OUTPUT] [--to {python,json,instr}] [--flavor {mcs
 | `--to` | Target format (`python`, `json`, or `instr`) |
 | `--flavor` | Flavor used when reading `.instr` input (`mcstas` default) |
 | `-I`, `--search-dir` | Extra component search directory when reading `.instr` |
-| `--optimize` | Reserved for future optimized Python code-generation mode |
+| `--optimize` | Enable conservative loop-compaction for repeated component sequences (only with `--to python`) |

--- a/src/mccode_antlr/cli/convert.py
+++ b/src/mccode_antlr/cli/convert.py
@@ -62,16 +62,17 @@ def convert(
     source = Path(filename).resolve()
     target = _resolve_target(to, output)
 
-    if target == 'python':
-        raise NotImplementedError('Python export is planned but not part of PR1.')
     if optimize:
-        raise NotImplementedError('--optimize is only supported by the future Python exporter.')
+        raise NotImplementedError('--optimize is only supported by the future optimized Python exporter.')
 
     destination = Path(output).resolve() if output is not None else _default_output_path(source, target)
 
     instr = _load_instr(source, flavor, search_dir)
 
-    if target == 'json':
+    if target == 'python':
+        from mccode_antlr.export import save_instr_as_python
+        save_instr_as_python(instr, destination)
+    elif target == 'json':
         from mccode_antlr.io.json import save_json
         save_json(instr, destination)
     elif target == 'instr':

--- a/src/mccode_antlr/cli/convert.py
+++ b/src/mccode_antlr/cli/convert.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mccode_antlr import Flavor
+from mccode_antlr.instr import Instr
+
+
+_TARGET_EXTENSION = {
+    'python': '.py',
+    'json': '.json',
+    'instr': '.instr',
+}
+
+
+def _resolve_target(to: str | None, output: str | None) -> str:
+    if to is not None:
+        target = to.lower()
+    elif output is not None:
+        target = {
+            '.py': 'python',
+            '.json': 'json',
+            '.instr': 'instr',
+        }.get(Path(output).suffix.lower(), 'python')
+    else:
+        target = 'python'
+    if target not in _TARGET_EXTENSION:
+        raise ValueError(f'Unknown conversion target {target!r}')
+    return target
+
+
+def _default_output_path(input_path: Path, target: str) -> Path:
+    suffix = _TARGET_EXTENSION[target]
+    if input_path.suffix.lower() == suffix:
+        return input_path.with_name(f'{input_path.stem}.converted{suffix}')
+    return input_path.with_suffix(suffix)
+
+
+def _load_instr(path: Path, flavor: str, search_dir: list[Path] | None):
+    if path.suffix.lower() == '.json':
+        from mccode_antlr.io.json import load_json
+        instr = load_json(path)
+    elif path.suffix.lower() == '.instr':
+        from mccode_antlr.reader import Reader, collect_local_registries
+        registries = collect_local_registries(Flavor[flavor.upper()], search_dir)
+        instr = Reader(registries=registries).get_instrument(path)
+    else:
+        raise ValueError(f"Unsupported input file type {path.suffix!r}; expected .instr or .json")
+    if not isinstance(instr, Instr):
+        raise RuntimeError(f'Input {path} did not resolve to an Instr object')
+    return instr
+
+
+def convert(
+        filename: str,
+        output: str | None = None,
+        to: str | None = None,
+        optimize: bool = False,
+        flavor: str = 'mcstas',
+        search_dir: list[Path] | None = None,
+):
+    source = Path(filename).resolve()
+    target = _resolve_target(to, output)
+
+    if target == 'python':
+        raise NotImplementedError('Python export is planned but not part of PR1.')
+    if optimize:
+        raise NotImplementedError('--optimize is only supported by the future Python exporter.')
+
+    destination = Path(output).resolve() if output is not None else _default_output_path(source, target)
+
+    instr = _load_instr(source, flavor, search_dir)
+
+    if target == 'json':
+        from mccode_antlr.io.json import save_json
+        save_json(instr, destination)
+    elif target == 'instr':
+        with destination.open('w') as f:
+            instr.to_file(output=f)
+    else:
+        raise ValueError(f'No output logic for target {target!r}')
+
+    print(destination)
+
+
+def add_convert_management_parser(modes):
+    parser = modes.add_parser(
+        name='convert',
+        help='Convert instrument descriptions between file formats',
+    )
+    parser.add_argument(
+        'filename',
+        type=str,
+        help='Input file path (.instr or .json)',
+    )
+    parser.add_argument(
+        '-o', '--output',
+        default=None,
+        help='Output filename (if omitted, inferred from input and target)',
+    )
+    parser.add_argument(
+        '--to',
+        default=None,
+        choices=['python', 'json', 'instr'],
+        help='Target format (default: infer from --output extension, else python)',
+    )
+    parser.add_argument(
+        '--optimize',
+        action='store_true',
+        help='Enable optimization of generated Python output (future)',
+    )
+    parser.add_argument(
+        '--flavor',
+        default='mcstas',
+        choices=['mcstas', 'mcxtrace'],
+        help='Flavor used when loading .instr input (default: mcstas)',
+    )
+    parser.add_argument(
+        '-I', '--search-dir',
+        action='append',
+        type=Path,
+        help='Extra component search directory for .instr input',
+    )
+    parser.set_defaults(action=convert)
+    return parser

--- a/src/mccode_antlr/cli/convert.py
+++ b/src/mccode_antlr/cli/convert.py
@@ -62,20 +62,21 @@ def convert(
     source = Path(filename).resolve()
     target = _resolve_target(to, output)
 
-    if optimize:
-        raise NotImplementedError('--optimize is only supported by the future optimized Python exporter.')
-
     destination = Path(output).resolve() if output is not None else _default_output_path(source, target)
 
     instr = _load_instr(source, flavor, search_dir)
 
     if target == 'python':
         from mccode_antlr.export import save_instr_as_python
-        save_instr_as_python(instr, destination)
+        save_instr_as_python(instr, destination, optimize=optimize)
     elif target == 'json':
+        if optimize:
+            raise ValueError('--optimize is only supported when --to python')
         from mccode_antlr.io.json import save_json
         save_json(instr, destination)
     elif target == 'instr':
+        if optimize:
+            raise ValueError('--optimize is only supported when --to python')
         with destination.open('w') as f:
             instr.to_file(output=f)
     else:
@@ -108,7 +109,7 @@ def add_convert_management_parser(modes):
     parser.add_argument(
         '--optimize',
         action='store_true',
-        help='Enable optimization of generated Python output (future)',
+        help='Enable conservative optimization of generated Python output',
     )
     parser.add_argument(
         '--flavor',

--- a/src/mccode_antlr/cli/management.py
+++ b/src/mccode_antlr/cli/management.py
@@ -183,12 +183,14 @@ def mccode_management_parser():
     """CLI interface to managing configuration and cache"""
     from argparse import ArgumentParser
     from mccode_antlr.cli.datafile import add_datafile_management_parser
+    from mccode_antlr.cli.convert import add_convert_management_parser
     parser = ArgumentParser(prog="mccode-antlr",
                             description='Manage mccode-antlr')
     modes = parser.add_subparsers(title='mode', help='Mode')
     add_cache_management_parser(modes)
     add_config_management_parser(modes)
     add_datafile_management_parser(modes)
+    add_convert_management_parser(modes)
     return parser
 
 

--- a/src/mccode_antlr/export/__init__.py
+++ b/src/mccode_antlr/export/__init__.py
@@ -1,0 +1,3 @@
+from .python import instr_to_python, save_instr_as_python
+
+__all__ = ['instr_to_python', 'save_instr_as_python']

--- a/src/mccode_antlr/export/python.py
+++ b/src/mccode_antlr/export/python.py
@@ -301,26 +301,18 @@ def _emit_loop_group(group: _LoopGroup, chunk, instance_names: dict[str, str]) -
     return lines
 
 
-def _emit_registry(reg, index: int) -> list[str]:
-    name = f'reg_{index}'
-    if isinstance(reg, LocalRegistry):
-        return [f'    {name} = LocalRegistry({reg.name!r}, {reg.root.as_posix()!r}, priority={reg.priority!r})']
-    if isinstance(reg, GitHubRegistry):
-        return [f'    {name} = GitHubRegistry({reg.name!r}, {reg.url!r}, {reg.version!r}, '
-                f'filename={reg.filename!r}, registry={reg.registry!r}, priority={reg.priority!r})']
-    if isinstance(reg, ModuleRemoteRegistry):
-        return [f'    {name} = ModuleRemoteRegistry({reg.name!r}, {reg.url!r}, '
-                f'filename={reg.filename!r}, version={reg.version!r}, priority={reg.priority!r})']
-    if isinstance(reg, RemoteRegistry):
-        return [f'    {name} = RemoteRegistry({reg.name!r}, {reg.url!r}, {reg.version!r}, '
-                f'{reg.filename!r}, priority={reg.priority!r})']
-    if isinstance(reg, InMemoryRegistry):
-        lines = [f'    {name} = InMemoryRegistry({reg.name!r}, priority={reg.priority!r})']
+def _handle_registry(reg) -> tuple[str|None, list[str]]:
+    rep, lines = None, []
+    if isinstance(reg, (LocalRegistry, GitHubRegistry, ModuleRemoteRegistry, RemoteRegistry)):
+        rep = f'registry_from_specification("{reg.specification_string()}")'
+    elif isinstance(reg, InMemoryRegistry):
+        rep = f'InMemoryRegistry({reg.name!r}, priority={reg.priority!r})'
+        lines.append('    # This may not work -- good luck!')
         for comp_name, source in reg.components.items():
             lines.append(f'    {name}.add({comp_name!r}, {source!r})')
-        return lines
-    return [f'    # Unsupported registry type preserved as comment: {type(reg).__name__}({reg!r})',
-            f'    {name} = None']
+    else:
+        lines = [f'    # Unsupported registry type preserved as comment: {type(reg).__name__}({reg!r})',]
+    return rep, lines
 
 
 def instr_to_python(instr: Instr, optimize: bool = False) -> str:
@@ -354,14 +346,20 @@ def instr_to_python(instr: Instr, optimize: bool = False) -> str:
     if has_metadata:
         lines.append('from mccode_antlr.common import MetaData')
         lines.append('from mccode_antlr.common.metadata import DataSource')
+
+    lines.append('from mccode_antlr.reader.registry import registry_from_specification')
+
     lines.extend(['', '', 'def build_instrument():'])
 
     if instr.registries:
         lines.append('    registries = []')
         for i, reg in enumerate(instr.registries, start=1):
-            lines.extend(_emit_registry(reg, i))
-            lines.append(f'    if reg_{i} is not None:')
-            lines.append(f'        registries.append(reg_{i})')
+            obj, extras = _handle_registry(reg)
+            if obj:
+                lines.append(f'    if (reg := {obj}) is not None:')
+                lines.append('        registries.append(reg)')
+            if len(extras):
+                lines.extend(extras)
         lines.append(f'    a = Assembler({instr.name!r}, registries=registries)')
     else:
         lines.append(f'    a = Assembler({instr.name!r}, flavor=Flavor.{_infer_flavor(instr)})')

--- a/src/mccode_antlr/export/python.py
+++ b/src/mccode_antlr/export/python.py
@@ -115,16 +115,72 @@ def _vector_axis_progression(vectors) -> tuple[int, int | float, int | float] | 
 
 @dataclass
 class _LoopGroup:
+    mode: str
     start: int
     end: int
     prefix: str
     start_index: int
-    at_axis: int
-    at_base: int | float
-    at_delta: int | float
+    at_axis: int | None = None
+    at_base: int | float | None = None
+    at_delta: int | float | None = None
 
 
 def _find_loop_groups(components: tuple) -> list[_LoopGroup]:
+    def static_signature(inst):
+        return (
+            inst.type.name,
+            tuple((p.name, _expr_text(p.value)) for p in inst.parameters),
+            None if inst.when is None else _expr_text(inst.when),
+            inst.group,
+            inst.removable,
+            inst.cpu,
+            None if inst.split is None else _expr_text(inst.split),
+            tuple(ext.source for ext in inst.extend),
+            tuple((j.target, j.relative_target, j.iterate, _expr_text(j.condition), j.absolute_target) for j in inst.jump),
+            tuple((md.source.type_name, md.source.name, md.name, md.mimetype, md.value) for md in inst.metadata),
+        )
+
+    def vector_text(v):
+        return tuple(_expr_text(x) for x in v)
+
+    def previous_chain_candidate(chunk, start, end, series):
+        if len(chunk) < 3:
+            return None
+        signatures = [static_signature(inst) for inst in chunk]
+        if not all(sig == signatures[0] for sig in signatures):
+            return None
+        at_delta = vector_text(chunk[1].at_relative[0])
+        rotate_delta = vector_text(chunk[1].rotate_relative[0])
+        for k in range(1, len(chunk)):
+            prev = chunk[k - 1]
+            curr = chunk[k]
+            if _ref_name(curr.at_relative[1]) != prev.name:
+                return None
+            if _ref_name(curr.rotate_relative[1]) != prev.name:
+                return None
+            if vector_text(curr.at_relative[0]) != at_delta:
+                return None
+            if vector_text(curr.rotate_relative[0]) != rotate_delta:
+                return None
+        return _LoopGroup(mode='previous_chain', start=start, end=end,
+                          prefix=series[0], start_index=series[1])
+
+    def absolute_candidate(chunk, start, end, series):
+        signatures = [_instance_signature(inst) for inst in chunk]
+        if not all(sig == signatures[0] for sig in signatures):
+            return None
+        names = [inst.name for inst in chunk]
+        at_ref = _ref_name(chunk[0].at_relative[1])
+        if at_ref is not None and at_ref in names:
+            return None
+        vectors = [inst.at_relative[0] for inst in chunk]
+        axis_prog = _vector_axis_progression(vectors)
+        if axis_prog is None:
+            return None
+        axis, base, delta = axis_prog
+        return _LoopGroup(mode='absolute_axis', start=start, end=end, prefix=series[0], start_index=series[1],
+                          at_axis=axis, at_base=base, at_delta=delta)
+
     groups: list[_LoopGroup] = []
     i = 0
     while i < len(components):
@@ -135,21 +191,11 @@ def _find_loop_groups(components: tuple) -> list[_LoopGroup]:
             series = _name_series(names)
             if series is None:
                 break
-            signatures = [_instance_signature(inst) for inst in chunk]
-            if not all(sig == signatures[0] for sig in signatures):
-                continue
-
-            at_ref = _ref_name(chunk[0].at_relative[1])
-            if at_ref is not None and at_ref in names:
-                continue
-
-            vectors = [inst.at_relative[0] for inst in chunk]
-            axis_prog = _vector_axis_progression(vectors)
-            if axis_prog is None:
-                continue
-            axis, base, delta = axis_prog
-            best = _LoopGroup(start=i, end=j, prefix=series[0], start_index=series[1],
-                              at_axis=axis, at_base=base, at_delta=delta)
+            candidate = previous_chain_candidate(chunk, i, j, series)
+            if candidate is None:
+                candidate = absolute_candidate(chunk, i, j, series)
+            if candidate is not None:
+                best = candidate
         if best is not None:
             groups.append(best)
             i = best.end
@@ -158,13 +204,13 @@ def _find_loop_groups(components: tuple) -> list[_LoopGroup]:
     return groups
 
 
-def _emit_component(inst, var_name: str, instance_names: dict[str, str]) -> list[str]:
-    lines = []
+def _component_kwargs(inst, instance_names: dict[str, str], *, name_expr: str | None = None,
+                      at_expr: str | None = None, rotate_expr: str | None = None) -> list[str]:
     kwargs = [
-        f'name={inst.name!r}',
+        f'name={name_expr if name_expr is not None else repr(inst.name)}',
         f'type_name={inst.type.name!r}',
-        f'at={_emit_vector_reference(inst.at_relative, instance_names)}',
-        f'rotate={_emit_vector_reference(inst.rotate_relative, instance_names)}',
+        f'at={at_expr if at_expr is not None else _emit_vector_reference(inst.at_relative, instance_names)}',
+        f'rotate={rotate_expr if rotate_expr is not None else _emit_vector_reference(inst.rotate_relative, instance_names)}',
     ]
     if inst.parameters:
         param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
@@ -179,12 +225,13 @@ def _emit_component(inst, var_name: str, instance_names: dict[str, str]) -> list
         kwargs.append('cpu=True')
     if inst.split is not None:
         kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
+    return kwargs
 
-    lines.append(f'    {var_name} = a.component({", ".join(kwargs)})')
 
+def _emit_component_post(lines: list[str], inst, var_name: str, indent: str = '    '):
     if inst.extend:
         blocks = ', '.join(repr(ext.source) for ext in inst.extend)
-        lines.append(f'    {var_name}.EXTEND({blocks})')
+        lines.append(f'{indent}{var_name}.EXTEND({blocks})')
     if inst.jump:
         jumps = []
         for jump in inst.jump:
@@ -193,19 +240,46 @@ def _emit_component(inst, var_name: str, instance_names: dict[str, str]) -> list
                 f'iterate={jump.iterate!r}, condition=Expr.parse({str(jump.condition)!r}), '
                 f'absolute_target={jump.absolute_target!r})'
             )
-        lines.append(f'    {var_name}.JUMP({", ".join(jumps)})')
+        lines.append(f'{indent}{var_name}.JUMP({", ".join(jumps)})')
     for md in inst.metadata:
         lines.append(
-            f'    {var_name}.add_metadata(MetaData('
+            f'{indent}{var_name}.add_metadata(MetaData('
             f'DataSource.from_type_name_and_name({md.source.type_name!r}, {md.source.name!r}), '
             f'{md.name!r}, {md.mimetype!r}, {md.value!r}))'
         )
+
+
+def _emit_component(inst, var_name: str, instance_names: dict[str, str]) -> list[str]:
+    lines = []
+    kwargs = _component_kwargs(inst, instance_names)
+    lines.append(f'    {var_name} = a.component({", ".join(kwargs)})')
+    _emit_component_post(lines, inst, var_name, indent='    ')
     return lines
 
 
-def _emit_loop_group(group: _LoopGroup, inst, instance_names: dict[str, str]) -> list[str]:
+def _emit_loop_group(group: _LoopGroup, chunk, instance_names: dict[str, str]) -> list[str]:
     lines = []
+    inst = chunk[0]
     n = group.end - group.start
+    if group.mode == 'previous_chain':
+        seed_kwargs = _component_kwargs(inst, instance_names)
+        lines.append(f'    last = a.component({", ".join(seed_kwargs)})')
+        _emit_component_post(lines, inst, 'last', indent='    ')
+
+        delta_inst = chunk[1]
+        at_delta = ', '.join(_expr_as_python_literal(x) for x in delta_inst.at_relative[0])
+        rot_delta = ', '.join(_expr_as_python_literal(x) for x in delta_inst.rotate_relative[0])
+        lines.append(f'    for i in range({n - 1}):')
+        kwargs = _component_kwargs(
+            delta_inst, instance_names,
+            name_expr=f'f"{group.prefix}{{i + {group.start_index + 1}}}"',
+            at_expr=f'([{at_delta}], last)',
+            rotate_expr=f'([{rot_delta}], last)',
+        )
+        lines.append(f'        last = a.component({", ".join(kwargs)})')
+        _emit_component_post(lines, delta_inst, 'last', indent='        ')
+        return lines
+
     lines.append(f'    for i in range({n}):')
     at_values = [_expr_as_python_literal(x) for x in inst.at_relative[0]]
     at_values[group.at_axis] = f'({group.at_base!r} + i * {group.at_delta!r})'
@@ -216,28 +290,14 @@ def _emit_loop_group(group: _LoopGroup, inst, instance_names: dict[str, str]) ->
         at_ref_repr = instance_names.get(at_ref.name, repr(at_ref.name))
     at_repr = f'([{", ".join(at_values)}], {at_ref_repr})'
     rotate_repr = _emit_vector_reference(inst.rotate_relative, instance_names)
-
-    kwargs = [
-        f'name=f"{group.prefix}{{i + {group.start_index}}}"',
-        f'type_name={inst.type.name!r}',
-        f'at={at_repr}',
-        f'rotate={rotate_repr}',
-    ]
-    if inst.parameters:
-        param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
-        kwargs.append(f'parameters={{{", ".join(param_pairs)}}}')
-    if inst.when is not None:
-        kwargs.append(f'when=Expr.parse({str(inst.when)!r})')
-    if inst.group is not None:
-        kwargs.append(f'group={inst.group!r}')
-    if inst.removable:
-        kwargs.append('removable=True')
-    if inst.cpu:
-        kwargs.append('cpu=True')
-    if inst.split is not None:
-        kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
-
-    lines.append(f'        a.component({", ".join(kwargs)})')
+    kwargs = _component_kwargs(
+        inst, instance_names,
+        name_expr=f'f"{group.prefix}{{i + {group.start_index}}}"',
+        at_expr=at_repr,
+        rotate_expr=rotate_repr,
+    )
+    lines.append(f'        _loop_inst = a.component({", ".join(kwargs)})')
+    _emit_component_post(lines, inst, '_loop_inst', indent='        ')
     return lines
 
 
@@ -328,7 +388,7 @@ def instr_to_python(instr: Instr, optimize: bool = False) -> str:
     while i < len(instr.components):
         if i in groups_by_start:
             group = groups_by_start[i]
-            lines.extend(_emit_loop_group(group, instr.components[group.start], instance_names))
+            lines.extend(_emit_loop_group(group, instr.components[group.start:group.end], instance_names))
             i = group.end
             continue
 

--- a/src/mccode_antlr/export/python.py
+++ b/src/mccode_antlr/export/python.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from dataclasses import dataclass
 
 from mccode_antlr.instr import Instr
 from mccode_antlr.reader import (
@@ -45,6 +46,201 @@ def _emit_vector_reference(vr, instances: dict[str, str]) -> str:
     return f'({vec_repr}, {instances.get(ref.name, repr(ref.name))})'
 
 
+def _ref_name(ref) -> str | None:
+    return None if ref is None else ref.name
+
+
+def _expr_text(expr) -> str:
+    return str(expr)
+
+
+def _expr_num(expr):
+    if not expr.has_value:
+        return None
+    value = expr.value
+    return value if isinstance(value, (int, float)) else None
+
+
+def _instance_signature(inst) -> tuple:
+    return (
+        inst.type.name,
+        tuple((p.name, _expr_text(p.value)) for p in inst.parameters),
+        _ref_name(inst.at_relative[1]),
+        tuple(_expr_text(x) for x in inst.rotate_relative[0]),
+        _ref_name(inst.rotate_relative[1]),
+        None if inst.when is None else _expr_text(inst.when),
+        inst.group,
+        inst.removable,
+        inst.cpu,
+        None if inst.split is None else _expr_text(inst.split),
+        tuple(ext.source for ext in inst.extend),
+        tuple((j.target, j.relative_target, j.iterate, _expr_text(j.condition), j.absolute_target) for j in inst.jump),
+        tuple((md.source.type_name, md.source.name, md.name, md.mimetype, md.value) for md in inst.metadata),
+    )
+
+
+def _name_series(instance_names: list[str]) -> tuple[str, int] | None:
+    import re
+    first = re.match(r'^(.*?)(\d+)$', instance_names[0])
+    if first is None:
+        return None
+    prefix = first.group(1)
+    start = int(first.group(2))
+    width = len(first.group(2))
+    for i, name in enumerate(instance_names[1:], start=1):
+        m = re.match(r'^(.*?)(\d+)$', name)
+        if m is None or m.group(1) != prefix or len(m.group(2)) != width or int(m.group(2)) != start + i:
+            return None
+    return prefix, start
+
+
+def _vector_axis_progression(vectors) -> tuple[int, int | float, int | float] | None:
+    values = [[_expr_num(x) for x in vec] for vec in vectors]
+    if any(any(v is None for v in row) for row in values):
+        return None
+    varying_axes = []
+    axis_data = None
+    for axis in range(3):
+        seq = [row[axis] for row in values]
+        delta = seq[1] - seq[0]
+        if any((seq[i] - seq[i - 1]) != delta for i in range(2, len(seq))):
+            return None
+        if delta != 0:
+            varying_axes.append(axis)
+            axis_data = (axis, seq[0], delta)
+    if len(varying_axes) != 1:
+        return None
+    return axis_data
+
+
+@dataclass
+class _LoopGroup:
+    start: int
+    end: int
+    prefix: str
+    start_index: int
+    at_axis: int
+    at_base: int | float
+    at_delta: int | float
+
+
+def _find_loop_groups(components: tuple) -> list[_LoopGroup]:
+    groups: list[_LoopGroup] = []
+    i = 0
+    while i < len(components):
+        best: _LoopGroup | None = None
+        for j in range(i + 3, len(components) + 1):
+            chunk = components[i:j]
+            names = [inst.name for inst in chunk]
+            series = _name_series(names)
+            if series is None:
+                break
+            signatures = [_instance_signature(inst) for inst in chunk]
+            if not all(sig == signatures[0] for sig in signatures):
+                continue
+
+            at_ref = _ref_name(chunk[0].at_relative[1])
+            if at_ref is not None and at_ref in names:
+                continue
+
+            vectors = [inst.at_relative[0] for inst in chunk]
+            axis_prog = _vector_axis_progression(vectors)
+            if axis_prog is None:
+                continue
+            axis, base, delta = axis_prog
+            best = _LoopGroup(start=i, end=j, prefix=series[0], start_index=series[1],
+                              at_axis=axis, at_base=base, at_delta=delta)
+        if best is not None:
+            groups.append(best)
+            i = best.end
+        else:
+            i += 1
+    return groups
+
+
+def _emit_component(inst, var_name: str, instance_names: dict[str, str]) -> list[str]:
+    lines = []
+    kwargs = [
+        f'name={inst.name!r}',
+        f'type_name={inst.type.name!r}',
+        f'at={_emit_vector_reference(inst.at_relative, instance_names)}',
+        f'rotate={_emit_vector_reference(inst.rotate_relative, instance_names)}',
+    ]
+    if inst.parameters:
+        param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
+        kwargs.append(f'parameters={{{", ".join(param_pairs)}}}')
+    if inst.when is not None:
+        kwargs.append(f'when=Expr.parse({str(inst.when)!r})')
+    if inst.group is not None:
+        kwargs.append(f'group={inst.group!r}')
+    if inst.removable:
+        kwargs.append('removable=True')
+    if inst.cpu:
+        kwargs.append('cpu=True')
+    if inst.split is not None:
+        kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
+
+    lines.append(f'    {var_name} = a.component({", ".join(kwargs)})')
+
+    if inst.extend:
+        blocks = ', '.join(repr(ext.source) for ext in inst.extend)
+        lines.append(f'    {var_name}.EXTEND({blocks})')
+    if inst.jump:
+        jumps = []
+        for jump in inst.jump:
+            jumps.append(
+                f'Jump(target={jump.target!r}, relative_target={jump.relative_target!r}, '
+                f'iterate={jump.iterate!r}, condition=Expr.parse({str(jump.condition)!r}), '
+                f'absolute_target={jump.absolute_target!r})'
+            )
+        lines.append(f'    {var_name}.JUMP({", ".join(jumps)})')
+    for md in inst.metadata:
+        lines.append(
+            f'    {var_name}.add_metadata(MetaData('
+            f'DataSource.from_type_name_and_name({md.source.type_name!r}, {md.source.name!r}), '
+            f'{md.name!r}, {md.mimetype!r}, {md.value!r}))'
+        )
+    return lines
+
+
+def _emit_loop_group(group: _LoopGroup, inst, instance_names: dict[str, str]) -> list[str]:
+    lines = []
+    n = group.end - group.start
+    lines.append(f'    for i in range({n}):')
+    at_values = [_expr_as_python_literal(x) for x in inst.at_relative[0]]
+    at_values[group.at_axis] = f'({group.at_base!r} + i * {group.at_delta!r})'
+    at_ref = inst.at_relative[1]
+    if at_ref is None:
+        at_ref_repr = '"ABSOLUTE"'
+    else:
+        at_ref_repr = instance_names.get(at_ref.name, repr(at_ref.name))
+    at_repr = f'([{", ".join(at_values)}], {at_ref_repr})'
+    rotate_repr = _emit_vector_reference(inst.rotate_relative, instance_names)
+
+    kwargs = [
+        f'name=f"{group.prefix}{{i + {group.start_index}}}"',
+        f'type_name={inst.type.name!r}',
+        f'at={at_repr}',
+        f'rotate={rotate_repr}',
+    ]
+    if inst.parameters:
+        param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
+        kwargs.append(f'parameters={{{", ".join(param_pairs)}}}')
+    if inst.when is not None:
+        kwargs.append(f'when=Expr.parse({str(inst.when)!r})')
+    if inst.group is not None:
+        kwargs.append(f'group={inst.group!r}')
+    if inst.removable:
+        kwargs.append('removable=True')
+    if inst.cpu:
+        kwargs.append('cpu=True')
+    if inst.split is not None:
+        kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
+
+    lines.append(f'        a.component({", ".join(kwargs)})')
+    return lines
+
+
 def _emit_registry(reg, index: int) -> list[str]:
     name = f'reg_{index}'
     if isinstance(reg, LocalRegistry):
@@ -67,7 +263,7 @@ def _emit_registry(reg, index: int) -> list[str]:
             f'    {name} = None']
 
 
-def instr_to_python(instr: Instr) -> str:
+def instr_to_python(instr: Instr, optimize: bool = False) -> str:
     has_metadata = bool(instr.metadata) or any(inst.metadata for inst in instr.components)
     has_jump = any(inst.jump for inst in instr.components)
     has_expr_array = any(
@@ -127,50 +323,20 @@ def instr_to_python(instr: Instr) -> str:
 
     instance_names: dict[str, str] = {}
     used_vars: set[str] = set()
-    for inst in instr.components:
+    groups_by_start = {g.start: g for g in _find_loop_groups(instr.components)} if optimize else {}
+    i = 0
+    while i < len(instr.components):
+        if i in groups_by_start:
+            group = groups_by_start[i]
+            lines.extend(_emit_loop_group(group, instr.components[group.start], instance_names))
+            i = group.end
+            continue
+
+        inst = instr.components[i]
         var_name = _safe_name(inst.name, used_vars)
         instance_names[inst.name] = var_name
-
-        kwargs = [
-            f'name={inst.name!r}',
-            f'type_name={inst.type.name!r}',
-            f'at={_emit_vector_reference(inst.at_relative, instance_names)}',
-            f'rotate={_emit_vector_reference(inst.rotate_relative, instance_names)}',
-        ]
-        if inst.parameters:
-            param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
-            kwargs.append(f'parameters={{{", ".join(param_pairs)}}}')
-        if inst.when is not None:
-            kwargs.append(f'when=Expr.parse({str(inst.when)!r})')
-        if inst.group is not None:
-            kwargs.append(f'group={inst.group!r}')
-        if inst.removable:
-            kwargs.append('removable=True')
-        if inst.cpu:
-            kwargs.append('cpu=True')
-        if inst.split is not None:
-            kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
-
-        lines.append(f'    {var_name} = a.component({", ".join(kwargs)})')
-
-        if inst.extend:
-            blocks = ', '.join(repr(ext.source) for ext in inst.extend)
-            lines.append(f'    {var_name}.EXTEND({blocks})')
-        if inst.jump:
-            jumps = []
-            for jump in inst.jump:
-                jumps.append(
-                    f'Jump(target={jump.target!r}, relative_target={jump.relative_target!r}, '
-                    f'iterate={jump.iterate!r}, condition=Expr.parse({str(jump.condition)!r}), '
-                    f'absolute_target={jump.absolute_target!r})'
-                )
-            lines.append(f'    {var_name}.JUMP({", ".join(jumps)})')
-        for md in inst.metadata:
-            lines.append(
-                f'    {var_name}.add_metadata(MetaData('
-                f'DataSource.from_type_name_and_name({md.source.type_name!r}, {md.source.name!r}), '
-                f'{md.name!r}, {md.mimetype!r}, {md.value!r}))'
-            )
+        lines.extend(_emit_component(inst, var_name, instance_names))
+        i += 1
 
     lines.extend([
         '    return a.instrument',
@@ -183,5 +349,5 @@ def instr_to_python(instr: Instr) -> str:
     return '\n'.join(lines) + '\n'
 
 
-def save_instr_as_python(instr: Instr, filename: str | Path) -> None:
-    Path(filename).write_text(instr_to_python(instr))
+def save_instr_as_python(instr: Instr, filename: str | Path, optimize: bool = False) -> None:
+    Path(filename).write_text(instr_to_python(instr, optimize=optimize))

--- a/src/mccode_antlr/export/python.py
+++ b/src/mccode_antlr/export/python.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from mccode_antlr.instr import Instr
+from mccode_antlr.reader import (
+    LocalRegistry, RemoteRegistry, ModuleRemoteRegistry, GitHubRegistry, InMemoryRegistry
+)
+
+
+def _infer_flavor(instr: Instr) -> str:
+    names = {reg.name.lower() for reg in instr.registries}
+    return 'MCXTRACE' if 'mcxtrace' in names else 'MCSTAS'
+
+
+def _safe_name(name: str, used: set[str]) -> str:
+    import re
+    ident = re.sub(r'[^0-9a-zA-Z_]', '_', name)
+    if not ident or ident[0].isdigit():
+        ident = f'comp_{ident}'
+    ident = f'comp_{ident}'
+    candidate = ident
+    i = 1
+    while candidate in used:
+        i += 1
+        candidate = f'{ident}_{i}'
+    used.add(candidate)
+    return candidate
+
+
+def _expr_as_python_literal(expr) -> str:
+    if expr.is_vector and expr.vector_known:
+        return f"Expr.array({expr.value!r})"
+    if expr.has_value:
+        return repr(expr.value)
+    return repr(str(expr))
+
+
+def _emit_vector_reference(vr, instances: dict[str, str]) -> str:
+    vec, ref = vr
+    values = ', '.join(_expr_as_python_literal(x) for x in vec)
+    vec_repr = f'[{values}]'
+    if ref is None:
+        return f'({vec_repr}, "ABSOLUTE")'
+    return f'({vec_repr}, {instances.get(ref.name, repr(ref.name))})'
+
+
+def _emit_registry(reg, index: int) -> list[str]:
+    name = f'reg_{index}'
+    if isinstance(reg, LocalRegistry):
+        return [f'    {name} = LocalRegistry({reg.name!r}, {reg.root.as_posix()!r}, priority={reg.priority!r})']
+    if isinstance(reg, GitHubRegistry):
+        return [f'    {name} = GitHubRegistry({reg.name!r}, {reg.url!r}, {reg.version!r}, '
+                f'filename={reg.filename!r}, registry={reg.registry!r}, priority={reg.priority!r})']
+    if isinstance(reg, ModuleRemoteRegistry):
+        return [f'    {name} = ModuleRemoteRegistry({reg.name!r}, {reg.url!r}, '
+                f'filename={reg.filename!r}, version={reg.version!r}, priority={reg.priority!r})']
+    if isinstance(reg, RemoteRegistry):
+        return [f'    {name} = RemoteRegistry({reg.name!r}, {reg.url!r}, {reg.version!r}, '
+                f'{reg.filename!r}, priority={reg.priority!r})']
+    if isinstance(reg, InMemoryRegistry):
+        lines = [f'    {name} = InMemoryRegistry({reg.name!r}, priority={reg.priority!r})']
+        for comp_name, source in reg.components.items():
+            lines.append(f'    {name}.add({comp_name!r}, {source!r})')
+        return lines
+    return [f'    # Unsupported registry type preserved as comment: {type(reg).__name__}({reg!r})',
+            f'    {name} = None']
+
+
+def instr_to_python(instr: Instr) -> str:
+    has_metadata = bool(instr.metadata) or any(inst.metadata for inst in instr.components)
+    has_jump = any(inst.jump for inst in instr.components)
+    has_expr_array = any(
+        p.value.is_vector and p.value.vector_known
+        for inst in instr.components for p in inst.parameters
+    )
+    has_expr_parse = any(
+        (inst.when is not None or inst.split is not None or any(j.condition is not None for j in inst.jump))
+        for inst in instr.components
+    )
+
+    lines = [
+        'from __future__ import annotations',
+        '',
+        'from mccode_antlr import Flavor',
+        'from mccode_antlr.assembler import Assembler',
+    ]
+    if instr.registries:
+        lines.extend([
+            'from mccode_antlr.reader import (',
+            '    LocalRegistry, RemoteRegistry, ModuleRemoteRegistry, GitHubRegistry, InMemoryRegistry,',
+            ')',
+        ])
+    if has_expr_array or has_expr_parse:
+        lines.append('from mccode_antlr.common.expression import Expr')
+    if has_jump:
+        lines.append('from mccode_antlr.instr import Jump')
+    if has_metadata:
+        lines.append('from mccode_antlr.common import MetaData')
+        lines.append('from mccode_antlr.common.metadata import DataSource')
+    lines.extend(['', '', 'def build_instrument():'])
+
+    if instr.registries:
+        lines.append('    registries = []')
+        for i, reg in enumerate(instr.registries, start=1):
+            lines.extend(_emit_registry(reg, i))
+            lines.append(f'    if reg_{i} is not None:')
+            lines.append(f'        registries.append(reg_{i})')
+        lines.append(f'    a = Assembler({instr.name!r}, registries=registries)')
+    else:
+        lines.append(f'    a = Assembler({instr.name!r}, flavor=Flavor.{_infer_flavor(instr)})')
+
+    for par in instr.parameters:
+        lines.append(f'    a.parameter({str(par)!r})')
+    for block in instr.declare:
+        lines.append(f'    a.declare({block.source!r}, source={block.filename!r}, line={block.line!r})')
+    for block in instr.user:
+        lines.append(f'    a.user_vars({block.source!r}, source={block.filename!r}, line={block.line!r})')
+    for block in instr.initialize:
+        lines.append(f'    a.initialize({block.source!r}, source={block.filename!r}, line={block.line!r})')
+    for block in instr.save:
+        lines.append(f'    a.save({block.source!r}, source={block.filename!r}, line={block.line!r})')
+    for block in instr.final:
+        lines.append(f'    a.final({block.source!r}, source={block.filename!r}, line={block.line!r})')
+    for md in instr.metadata:
+        lines.append(f'    a.metadata(name={md.name!r}, mimetype={md.mimetype!r}, value={md.value!r}, source={md.source.name!r})')
+
+    instance_names: dict[str, str] = {}
+    used_vars: set[str] = set()
+    for inst in instr.components:
+        var_name = _safe_name(inst.name, used_vars)
+        instance_names[inst.name] = var_name
+
+        kwargs = [
+            f'name={inst.name!r}',
+            f'type_name={inst.type.name!r}',
+            f'at={_emit_vector_reference(inst.at_relative, instance_names)}',
+            f'rotate={_emit_vector_reference(inst.rotate_relative, instance_names)}',
+        ]
+        if inst.parameters:
+            param_pairs = [f'{p.name!r}: {_expr_as_python_literal(p.value)}' for p in inst.parameters]
+            kwargs.append(f'parameters={{{", ".join(param_pairs)}}}')
+        if inst.when is not None:
+            kwargs.append(f'when=Expr.parse({str(inst.when)!r})')
+        if inst.group is not None:
+            kwargs.append(f'group={inst.group!r}')
+        if inst.removable:
+            kwargs.append('removable=True')
+        if inst.cpu:
+            kwargs.append('cpu=True')
+        if inst.split is not None:
+            kwargs.append(f'split=Expr.parse({str(inst.split)!r})')
+
+        lines.append(f'    {var_name} = a.component({", ".join(kwargs)})')
+
+        if inst.extend:
+            blocks = ', '.join(repr(ext.source) for ext in inst.extend)
+            lines.append(f'    {var_name}.EXTEND({blocks})')
+        if inst.jump:
+            jumps = []
+            for jump in inst.jump:
+                jumps.append(
+                    f'Jump(target={jump.target!r}, relative_target={jump.relative_target!r}, '
+                    f'iterate={jump.iterate!r}, condition=Expr.parse({str(jump.condition)!r}), '
+                    f'absolute_target={jump.absolute_target!r})'
+                )
+            lines.append(f'    {var_name}.JUMP({", ".join(jumps)})')
+        for md in inst.metadata:
+            lines.append(
+                f'    {var_name}.add_metadata(MetaData('
+                f'DataSource.from_type_name_and_name({md.source.type_name!r}, {md.source.name!r}), '
+                f'{md.name!r}, {md.mimetype!r}, {md.value!r}))'
+            )
+
+    lines.extend([
+        '    return a.instrument',
+        '',
+        '',
+        "if __name__ == '__main__':",
+        '    instrument = build_instrument()',
+        '    print(instrument)',
+    ])
+    return '\n'.join(lines) + '\n'
+
+
+def save_instr_as_python(instr: Instr, filename: str | Path) -> None:
+    Path(filename).write_text(instr_to_python(instr))

--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -5,13 +5,16 @@ from functools import cache
 from pathlib import Path
 from re import Pattern
 from loguru import logger
-from mccode_antlr.version import version as mccode_antlr_version
-from mccode_antlr import Flavor
 from typing import Type, Any
 from msgspec import Struct
 import requests
 from time import sleep
 from packaging.version import Version, InvalidVersion
+
+from mccode_antlr.version import version as mccode_antlr_version
+from mccode_antlr import Flavor
+from mccode_antlr.common import TextWrapper
+
 
 def _fetch_registry_with_retry(url, max_retries=3, timeout=10):
     """Fetch a registry file with retry logic for gateway timeouts"""
@@ -83,7 +86,6 @@ class Registry:
     priority: int = 0
 
     def __str__(self):
-        from mccode_antlr.common import TextWrapper
         return self.to_string(TextWrapper())
 
     def __hash__(self):
@@ -95,8 +97,20 @@ class Registry:
         self.to_file(output, wrapper)
         return output.getvalue()
 
+#    def to_file(self, output, wrapper):
+#        print(f'Registry<{self.name=},{self.root=},{self.pooch=},{self.version=},{self.priority=}>', file=output)
+
+    def _inner_specification_parts(self, wrapper) -> list[str]:
+        return [self.name, self.root, self.pooch, self.version]
+
+    def specification_parts(self, wrapper=None) -> list[str]:
+        return self._inner_specification_parts(wrapper if wrapper else TextWrapper())
+
+    def specification_string(self) -> str:
+        return ' '.join(self.specification_parts())
+        
     def to_file(self, output, wrapper):
-        print(f'Registry<{self.name=},{self.root=},{self.pooch=},{self.version=},{self.priority=}>', file=output)
+        print(wrapper.line('Registry:', self.specification_parts(wrapper)), file=output)
 
     def known(self, name: str, ext: str = None, strict: bool = False):
         pass
@@ -173,10 +187,12 @@ class RemoteRegistry(Registry):
     def file_contents(self) -> dict[str, str]:
         return {key: getattr(self, key) or '' for key in self.file_keys()}
 
-    def to_file(self, output, wrapper):
+    def _inner_specification_parts(self, wrapper) -> list[str]:
         filename = self.filename or f'{self.name}-registry.txt'
-        print(wrapper.line('Registry:', [self.name, wrapper.url(self.url or ''), self.version or '', filename]),
-              file=output)
+        return [self.name, wrapper.url(self.url or ''), self.version or '', filename]
+        
+#    def to_file(self, output, wrapper):
+#        print(wrapper.line('Registry:', self.specification_parts(wrapper)), file=output)
 
     def known(self, name: str, ext: str = None, strict: bool = False):
         compare = _name_plus_suffix(name, ext)
@@ -316,12 +332,13 @@ class GitHubRegistry(RemoteRegistry):
     def registry(self):
         return self._stashed_registry
 
-    def to_file(self, output, wrapper):
+    def _inner_specification_parts(self, wrapper):
         filename = self.filename or f'{self.name}-registry.txt'
         items = [self.name, wrapper.url(self.url or ''), self.version or '', filename]
         if self._stashed_registry:
             items.append(wrapper.url(self._stashed_registry))
-        print(wrapper.line('Registry:', items), file=output)
+        return items
+        
 
     def file_contents(self) -> dict[str, str]:
         fc = super().file_contents()
@@ -349,8 +366,8 @@ class LocalRegistry(Registry):
     def file_contents(self):
         return {'name': self.name, 'root': self.root.as_posix(), 'priority': self.priority}
 
-    def to_file(self, output, wrapper):
-        print(wrapper.line('Registry:', [self.name, wrapper.url(self.root.as_posix())]), file=output)
+    def _inner_specification_parts(self, wrapper=None) -> list[str]:
+        return [self.name, wrapper.url(self.root.as_posix())]
 
     def _filetype_iterator(self, filetype: str):
         return self.root.glob(f'**/*.{filetype}')

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+
+def test_convert_parser_is_registered():
+    from mccode_antlr.cli.management import mccode_management_parser
+
+    parser = mccode_management_parser()
+    args = parser.parse_args(['convert', 'in.instr', '--to', 'json'])
+
+    assert hasattr(args, 'action')
+    assert args.to == 'json'
+    assert args.filename == 'in.instr'
+
+
+def test_convert_instr_to_json(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+    from mccode_antlr.io.json import load_json
+    from mccode_antlr.instr import Instr
+
+    instr = parse_mcstas_instr(
+        "define instrument check() trace component a = Arm() at (0,0,0) absolute end"
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'converted.json'
+    convert(filename=str(source), output=str(destination), to='json')
+
+    converted = load_json(destination)
+    assert isinstance(converted, Instr)
+    assert converted.name == instr.name
+    assert [c.name for c in converted.components] == [c.name for c in instr.components]
+
+
+def test_convert_json_to_instr(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+    from mccode_antlr.io.json import save_json
+
+    instr = parse_mcstas_instr(
+        "define instrument check() trace component a = Arm() at (0,0,0) absolute end"
+    )
+    source = tmp_path / 'source.json'
+    save_json(instr, source)
+
+    destination = tmp_path / 'converted.instr'
+    convert(filename=str(source), output=str(destination), to='instr')
+
+    text = destination.read_text()
+    assert 'DEFINE INSTRUMENT check' in text
+    assert 'COMPONENT a = Arm' in text

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,4 +1,5 @@
 import ast
+import pytest
 
 
 def test_convert_parser_is_registered():
@@ -95,3 +96,74 @@ def test_generated_python_builds_instr_object(tmp_path):
     assert isinstance(rebuilt, Instr)
     assert rebuilt.name == instr.name
     assert [c.name for c in rebuilt.components] == [c.name for c in instr.components]
+
+
+def test_convert_instr_to_python_optimized_uses_loop(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        """
+        define instrument check()
+        trace
+        component origin = Arm() at (0,0,0) absolute
+        component guide1 = Arm() at (0,0,1) relative origin
+        component guide2 = Arm() at (0,0,2) relative origin
+        component guide3 = Arm() at (0,0,3) relative origin
+        end
+        """
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'optimized.py'
+    convert(filename=str(source), output=str(destination), to='python', optimize=True)
+
+    text = destination.read_text()
+    assert 'for i in range(3):' in text
+    assert 'name=f"guide{i + 1}"' in text
+    ast.parse(text)
+
+
+def test_generated_optimized_python_preserves_component_names(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        """
+        define instrument check()
+        trace
+        component origin = Arm() at (0,0,0) absolute
+        component guide1 = Arm() at (0,0,1) relative origin
+        component guide2 = Arm() at (0,0,2) relative origin
+        component guide3 = Arm() at (0,0,3) relative origin
+        end
+        """
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'optimized.py'
+    convert(filename=str(source), output=str(destination), to='python', optimize=True)
+
+    namespace = {}
+    exec(destination.read_text(), namespace)
+    rebuilt = namespace['build_instrument']()
+    assert [c.name for c in rebuilt.components] == [c.name for c in instr.components]
+
+
+def test_optimize_rejected_for_non_python_target(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        "define instrument check() trace component a = Arm() at (0,0,0) absolute end"
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    with pytest.raises(ValueError, match='--optimize is only supported when --to python'):
+        convert(filename=str(source), output=str(tmp_path / 'out.json'), to='json', optimize=True)

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+import ast
 
 
 def test_convert_parser_is_registered():
@@ -51,3 +51,47 @@ def test_convert_json_to_instr(tmp_path):
     text = destination.read_text()
     assert 'DEFINE INSTRUMENT check' in text
     assert 'COMPONENT a = Arm' in text
+
+
+def test_convert_instr_to_python(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        "define instrument check() trace component a = Arm() at (0,0,0) absolute end"
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'converted.py'
+    convert(filename=str(source), output=str(destination), to='python')
+
+    text = destination.read_text()
+    assert 'def build_instrument()' in text
+    assert "a.component(name='a', type_name='Arm'" in text
+    ast.parse(text)
+
+
+def test_generated_python_builds_instr_object(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+    from mccode_antlr.instr import Instr
+
+    instr = parse_mcstas_instr(
+        "define instrument check() trace component a = Arm() at (0,0,0) absolute end"
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'converted.py'
+    convert(filename=str(source), output=str(destination), to='python')
+
+    namespace = {}
+    exec(destination.read_text(), namespace)
+    rebuilt = namespace['build_instrument']()
+
+    assert isinstance(rebuilt, Instr)
+    assert rebuilt.name == instr.name
+    assert [c.name for c in rebuilt.components] == [c.name for c in instr.components]

--- a/tests/test_cli_convert.py
+++ b/tests/test_cli_convert.py
@@ -167,3 +167,62 @@ def test_optimize_rejected_for_non_python_target(tmp_path):
 
     with pytest.raises(ValueError, match='--optimize is only supported when --to python'):
         convert(filename=str(source), output=str(tmp_path / 'out.json'), to='json', optimize=True)
+
+
+def test_convert_instr_to_python_optimized_previous_chain_uses_last(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        """
+        define instrument check()
+        trace
+        component origin = Arm() at (0,0,0) absolute
+        component guide1 = Arm() at (0,0,1) relative origin
+        component guide2 = Arm() at (0,0,1) relative guide1
+        component guide3 = Arm() at (0,0,1) relative guide2
+        end
+        """
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'optimized_prev.py'
+    convert(filename=str(source), output=str(destination), to='python', optimize=True)
+
+    text = destination.read_text()
+    assert 'last = a.component(' in text
+    assert 'for i in range(2):' in text
+    assert 'at=([0, 0, 1], last)' in text
+    ast.parse(text)
+
+
+def test_convert_instr_to_python_optimized_previous_chain_with_rotation(tmp_path):
+    from mccode_antlr.loader import parse_mcstas_instr
+    from mccode_antlr.cli.convert import convert
+
+    instr = parse_mcstas_instr(
+        """
+        define instrument check()
+        trace
+        component origin = Arm() at (0,0,0) absolute
+        component guide1 = Arm() at (0,0,1) relative origin rotated (0,1.5,0) relative origin
+        component guide2 = Arm() at (0,0,1) relative guide1 rotated (0,1.5,0) relative guide1
+        component guide3 = Arm() at (0,0,1) relative guide2 rotated (0,1.5,0) relative guide2
+        end
+        """
+    )
+    source = tmp_path / 'source.instr'
+    with source.open('w') as f:
+        instr.to_file(output=f)
+
+    destination = tmp_path / 'optimized_prev_rot.py'
+    convert(filename=str(source), output=str(destination), to='python', optimize=True)
+
+    text = destination.read_text()
+    assert 'rotate=([0, 1.5, 0], last)' in text
+    namespace = {}
+    exec(text, namespace)
+    rebuilt = namespace['build_instrument']()
+    assert [c.name for c in rebuilt.components] == [c.name for c in instr.components]


### PR DESCRIPTION
This pull request introduces a new `convert` CLI subcommand to the `mccode-antlr` tool, allowing users to convert instrument descriptions between `.instr`, `.json`, and Python assembler script formats. The implementation covers argument parsing, file format detection, and conversion logic, and is accompanied by comprehensive tests. Additionally, there are some codebase improvements and refactoring in the registry handling.

**Major features and changes:**

### New CLI Functionality

* Added a new `convert` subcommand to the CLI, documented in `docs/api/cli.md`, for converting instrument descriptions between `.instr`, `.json`, and Python assembler scripts, with options for target format, flavor, output path, search directories, and optimization. [[1]](diffhunk://#diff-dbd5fb3e13fd6ab32444eb4629a826b32ade030f9a3460b7edb01fbd963fa2d2R181) [[2]](diffhunk://#diff-dbd5fb3e13fd6ab32444eb4629a826b32ade030f9a3460b7edb01fbd963fa2d2R238-R256) [[3]](diffhunk://#diff-2201a811975836887ed93c7dd532d595deeb572d6b413d8bab1cae84bbf87628R186-R193) [[4]](diffhunk://#diff-77adf8b7ed3806e7551770d2512b3adcb22b289de8a85092aae222dc302898f7R1-R127)

### Implementation

* Implemented the `convert` logic in `src/mccode_antlr/cli/convert.py`, including target detection, format conversion, and argument parsing. The command supports an `--optimize` flag for Python output, and raises errors if used incorrectly.
* Exported the relevant Python export functions in `src/mccode_antlr/export/__init__.py` for use by the converter.

### Testing

* Added a comprehensive test suite in `tests/test_cli_convert.py` covering parser registration, all supported conversions, optimization logic, and error handling.

### Codebase Improvements

* Refactored registry handling in `src/mccode_antlr/reader/registry.py` to centralize and clarify the logic for registry specification string construction and output, using new `_inner_specification_parts` and `specification_parts` methods. [[1]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL8-R18) [[2]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL86) [[3]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bR100-R113) [[4]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL176-R195) [[5]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL319-R341) [[6]](diffhunk://#diff-d45cb80318a6425bf893b41c624c117f2d480155cebee661e4b7c7088022261bL352-R370)

These changes significantly improve the usability of the CLI for instrument file conversion and enhance code maintainability.