### PR TITLE
Refactor orientations

### DIFF
--- a/src/mccode_antlr/cli/commands.py
+++ b/src/mccode_antlr/cli/commands.py
@@ -46,8 +46,6 @@ def mccode(flavor: Flavor):
     args = mccode_script_parse(str(flavor).lower() + '-antlr')
     from mccode_antlr.reader import Reader, collect_local_registries
     from mccode_antlr.translators.c import CTargetVisitor
-    from mccode_antlr.common import Mode
-
     config = dict(default_main=args.main,
                   enable_trace=args.trace,
                   portable=args.portable,
@@ -66,8 +64,7 @@ def mccode(flavor: Flavor):
         # Construct the object which will read the instrument and component files, producing Python objects
         reader = Reader(registries=collect_local_registries(flavor, args.search_dir))
         # Read the provided .instr file, including all specified .instr and .comp files along the way
-        # In minimal mode, the component orientations are not resolved -- to speed up the process
-        instrument = reader.get_instrument(args.filename, mode=Mode.minimal)
+        instrument = reader.get_instrument(args.filename)
 
     # Construct the object which will translate the Python instrument to C
     visitor = CTargetVisitor(instrument, flavor=flavor, config=config, verbose=config['verbose'],

--- a/src/mccode_antlr/common/__init__.py
+++ b/src/mccode_antlr/common/__init__.py
@@ -3,7 +3,6 @@ from .expression import Expr, unary_expr, binary_expr, DataType, ShapeType, Obje
 from .metadata import MetaData
 from .block import RawC, blocks_to_raw_c
 from .textwrap import TextWrapper, HTMLWrapper
-from .mode import Mode
 from . import utilities
 
 __all__ = [
@@ -17,7 +16,6 @@ __all__ = [
     'ShapeType',
     'ObjectType',
     'MetaData',
-    'Mode',
     'RawC',
     'blocks_to_raw_c',
     'utilities',

--- a/src/mccode_antlr/common/mode.py
+++ b/src/mccode_antlr/common/mode.py
@@ -1,5 +1,0 @@
-from enum import Enum
-
-class Mode(Enum):
-    normal = 0
-    minimal = 1

--- a/src/mccode_antlr/display/instrument_display.py
+++ b/src/mccode_antlr/display/instrument_display.py
@@ -2,10 +2,9 @@
 
 Collects :class:`ComponentDisplay` objects for every component instance that
 has a ``MCDISPLAY`` section, transforms each component's local geometry into
-the global instrument coordinate frame using the symbolic
-:class:`~mccode_antlr.instr.orientation.Orient` chain already attached to
-each :class:`~mccode_antlr.instr.instance.Instance`, and then evaluates
-everything with a supplied instrument parameter dict.
+the global instrument coordinate frame using
+:meth:`~mccode_antlr.instr.instr.Instr.resolve_orientations`, and then
+evaluates everything with a supplied instrument parameter dict.
 
 Example::
 
@@ -128,6 +127,7 @@ class InstrumentDisplay:
         """
         p = dict(params or {})
         result: dict[str, list[np.ndarray]] = {}
+        orientations = self._instr.resolve_orientations() if global_frame else {}
 
         for instance in self._instr.components:
             name = instance.name
@@ -146,13 +146,13 @@ class InstrumentDisplay:
             cd = self._components[name]
             local_polylines = cd.to_polylines(comp_params)
 
-            if not global_frame or instance.orientation is None:
+            orient = orientations.get(name)
+            if not global_frame or orient is None:
                 result[name] = local_polylines
                 continue
 
             # Transform to global frame
             try:
-                orient = instance.orientation
                 rotation = orient.rotation()
                 translation = orient.position()
             except Exception:

--- a/src/mccode_antlr/display/render/brep.py
+++ b/src/mccode_antlr/display/render/brep.py
@@ -423,6 +423,7 @@ def instrument_to_assembly(
 
     p = params or {}
     placed: list = []
+    _orient_map = instr_display._instr.resolve_orientations()
 
     for instance in instr_display._instr.components:
         name = instance.name
@@ -456,9 +457,9 @@ def instrument_to_assembly(
             continue
 
         # Apply global-frame placement
-        if instance.orientation is not None:
+        orient = _orient_map.get(instance.name)
+        if orient is not None:
             try:
-                orient = instance.orientation
                 rotation = orient.rotation()
                 translation = orient.position()
                 tx = _eval_expr(translation.x, p)

--- a/src/mccode_antlr/display/render/plotly.py
+++ b/src/mccode_antlr/display/render/plotly.py
@@ -87,15 +87,12 @@ def show_geometry(
     _orient_map: dict = {}
     if use_mesh and instrument_display is not None:
         from ..instrument_display import _transform_polyline
-        for instance in instrument_display._instr.components:
-            if instance.orientation is not None:
-                try:
-                    _orient_map[instance.name] = (
-                        instance.orientation.rotation(),
-                        instance.orientation.position(),
-                    )
-                except Exception:
-                    pass
+        orientations = instrument_display._instr.resolve_orientations()
+        for name, orient in orientations.items():
+            try:
+                _orient_map[name] = (orient.rotation(), orient.position())
+            except Exception:
+                pass
 
     for i, (name, polylines) in enumerate(geometry.items()):
         color = auto_colors[i % len(auto_colors)]

--- a/src/mccode_antlr/instr/instance.py
+++ b/src/mccode_antlr/instr/instance.py
@@ -7,7 +7,7 @@ from typing import TypeVar, Union, Optional
 from ..comp import Comp
 from ..common import Expr, Mode
 from ..common import InstrumentParameter, ComponentParameter, MetaData, parameter_name_present, RawC, blocks_to_raw_c
-from .orientation import Orient, Vector, Angles
+from .orientation import Vector, Angles
 from .jump import Jump
 
 InstanceReference = TypeVar('InstanceReference', bound='Instance')
@@ -24,7 +24,6 @@ class Instance(Struct):
     type: Comp
     at_relative: VectorReference
     rotate_relative: AnglesReference
-    orientation: Optional[Orient] = None
     parameters: tuple[ComponentParameter, ...] = field(default_factory=tuple)
     removable: bool = False
     cpu: bool = False
@@ -119,24 +118,6 @@ class Instance(Struct):
                    mode=ref.mode)
 
     def __post_init__(self):
-        # TODO: Enhancement idea. Instead of building independent orientation chains
-        #       for each instance, as is done in the non-minimal Mode. The Instr
-        #       could hold a directed graph defining the chains, with nodes as instances
-        #       or instance names, and edges as the the chained operations linking
-        #       the dependency. This should make it easier to re-use relative
-        #       orientation information in other tools, e.g., moreniius.
-        if self.mode != Mode.minimal and self.orientation is None:
-            ar, rr = self.at_relative, self.rotate_relative
-            if not isinstance(ar[0], Vector) or not isinstance(rr[0], Angles):
-                logger.warning(f'Expected {ar=} and {rr=} to be Vector and Angles respectively')
-            if rr[1] is None and ar[1] is not None:
-                logger.warning(f'Expected rotation reference to be specified when at reference is specified')
-            at = ar[0] if isinstance(ar[0], Vector) else Vector(*ar[0])
-            an, ar = (ar[1].name, ar[1].orientation) if ar[1] else ("ABSOLUTE", None)
-            rt = rr[0] if isinstance(rr[0], Angles) else Angles(*rr[0])
-            rn, rr = (rr[1].name, rr[1].orientation) if rr[1] else (an, ar)
-            self.orientation = Orient.from_dependent_orientations(ar, at, rr, rt)
-        # check if the defining component is marked noacc, in which case this _is_ cpu only
         if not self.type.acc:
             self.cpu = True
 
@@ -268,14 +249,14 @@ class Instance(Struct):
 
     def copy(self):
         return Instance(self.name, self.type, self.at_relative, self.rotate_relative,
-                        orientation=self.orientation, parameters=self.parameters,
+                        parameters=self.parameters,
                         removable=self.removable, cpu=self.cpu, split=self.split, when=self.when,
                         group=self.group, extend=self.extend, jump=self.jump, metadata=self.metadata)
 
     def parameter_used(self, name: str):
         if any([name in par.value for par in self.parameters]):
             return True
-        if name in self.at_relative[0] or name in self.rotate_relative[0] or name in self.orientation:
+        if name in self.at_relative[0] or name in self.rotate_relative[0]:
             return True
         if name in (self.split or []) or name in (self.when or []):
             return True
@@ -332,7 +313,7 @@ class DepInstance(Instance):
         mreq = {'mode': Mode}
         tmreq = {'parameters': ComponentParameter, 'extend': RawC, 'jump': Jump,
                  'metadata': MetaData}
-        mopt = {'split': Expr, 'when': Expr, 'orientation': Orient, }
+        mopt = {'split': Expr, 'when': Expr}
         data = {k: args[k] for k in preq}
         data.update({k: args[k] for k in popt})
         data.update({k: t(args[k]) for k, t in mreq.items()})
@@ -345,6 +326,10 @@ class DepInstance(Instance):
         angles = Angles.from_dict(angles)
         data['at_relative'] = (vectors, ar_name)
         data['rotate_relative'] = angles, rr_name
+        # Strip keys that belonged to old serialized formats (e.g. 'orientation')
+        from msgspec.structs import fields as struct_fields
+        known = {f.name for f in struct_fields(cls)}
+        data = {k: v for k, v in data.items() if k in known}
         return cls(**data)
 
     def make_independent(self, components: dict[str, Comp]):
@@ -355,7 +340,6 @@ class DepInstance(Instance):
 
 def make_independent(dependents: tuple[DepInstance, ...], components: dict[str, Comp]):
     independents = [d.make_independent(components) for d in dependents]
-    # hopefully 'orientation' was set so no check was made against the relative instances
     names = tuple(i.name for i in independents)
     for d, t in zip(dependents, independents):
         if d.at_relative[1] in names:

--- a/src/mccode_antlr/instr/instance.py
+++ b/src/mccode_antlr/instr/instance.py
@@ -5,7 +5,7 @@ from typing import Optional
 from msgspec import Struct, field
 from typing import TypeVar, Union, Optional
 from ..comp import Comp
-from ..common import Expr, Mode
+from ..common import Expr
 from ..common import InstrumentParameter, ComponentParameter, MetaData, parameter_name_present, RawC, blocks_to_raw_c
 from .orientation import Vector, Angles
 from .jump import Jump
@@ -33,7 +33,6 @@ class Instance(Struct):
     extend: tuple[RawC, ...] = field(default_factory=tuple)
     jump: tuple[Jump, ...] = field(default_factory=tuple)
     metadata: tuple[MetaData, ...] = field(default_factory=tuple)
-    mode: Mode = Mode.normal
 
     def __eq__(self, other: Instance) -> bool:
         if not isinstance(other, Instance):
@@ -52,7 +51,7 @@ class Instance(Struct):
             (self.at_relative[0], _ref_id(self.at_relative[1])),
             (self.rotate_relative[0], _ref_id(self.rotate_relative[1])),
             self.parameters, self.removable, self.cpu, self.split,
-            self.when, self.group, self.extend, self.jump, self.metadata, self.mode
+            self.when, self.group, self.extend, self.jump, self.metadata
         ))
 
     def __repr__(self):
@@ -114,8 +113,7 @@ class Instance(Struct):
                    when=ref.when, group=ref.group,
                    extend=tuple([ext for ext in ref.extend]),
                    jump=tuple([jmp for jmp in ref.jump]),
-                   metadata=tuple([md for md in ref.metadata]),
-                   mode=ref.mode)
+                   metadata=tuple([md for md in ref.metadata]))
 
     def __post_init__(self):
         if not self.type.acc:
@@ -310,13 +308,11 @@ class DepInstance(Instance):
     def from_dict(cls, args: dict):
         preq = 'name', 'type', 'removable', 'cpu',
         popt = 'group',
-        mreq = {'mode': Mode}
         tmreq = {'parameters': ComponentParameter, 'extend': RawC, 'jump': Jump,
                  'metadata': MetaData}
         mopt = {'split': Expr, 'when': Expr}
         data = {k: args[k] for k in preq}
         data.update({k: args[k] for k in popt})
-        data.update({k: t(args[k]) for k, t in mreq.items()})
         data.update({k: t.from_dict(args[k]) for k, t in mopt.items() if k in args and args[k]})
         data.update({k: tuple(t.from_dict(a) for a in args[k]) for k, t in tmreq.items()})
 

--- a/src/mccode_antlr/instr/instr.py
+++ b/src/mccode_antlr/instr/instr.py
@@ -336,10 +336,11 @@ class Instr(Struct):
             component = reader.get_component(component)
 
         # ── 3. Auto-compute position / rotation if not provided ────────────────
+        orientations = self.resolve_orientations()
         if at_relative is None:
-            at_relative = _midpoint_at_relative(pred_inst, succ_inst)
+            at_relative = _midpoint_at_relative(pred_inst, succ_inst, orientations)
         if rotate_relative is None:
-            rotate_relative = _downstream_rotate_relative(pred_inst, succ_inst)
+            rotate_relative = _downstream_rotate_relative(pred_inst, succ_inst, orientations)
 
         # ── 4. Normalise vector/angles in at_relative / rotate_relative ────────
         from .orientation import Vector, Angles
@@ -347,8 +348,8 @@ class Instr(Struct):
         rotate_relative = _normalise_vr(rotate_relative, self.components, Angles)
 
         # ── 5. Fix forward references (ref must come before the new instance) ──
-        at_relative = _fix_forward_ref(at_relative, insert_idx, pred_inst)
-        rotate_relative = _fix_forward_ref_rotation(rotate_relative, insert_idx, pred_inst)
+        at_relative = _fix_forward_ref(at_relative, insert_idx, pred_inst, orientations)
+        rotate_relative = _fix_forward_ref_rotation(rotate_relative, insert_idx, pred_inst, orientations)
 
         # ── 6. Reject insertion that would break a contiguous group ───────────
         if (pred_inst is not None and succ_inst is not None
@@ -363,7 +364,7 @@ class Instr(Struct):
                 f"or pass group={pred_inst.group!r} to join the group."
             )
 
-        # ── 7. Create the instance (orientation computed in __post_init__) ──────
+        # ── 7. Create the instance ────────────────────────────────────────────────
         new_inst = Instance(name, component, at_relative, rotate_relative,
                             parameters=parameters, group=group, removable=removable)
 
@@ -649,6 +650,7 @@ class Instr(Struct):
         if first.check_instrument_parameters(remove=remove_unused_parameters) and not remove_unused_parameters:
             logger.warning(f'Instrument {first.name} has unused instrument parameters')
 
+        orig_orientations = self.resolve_orientations()
         second = self.copy(first=index)
         second.name = self.name + '_second'
         # remove any dangling component references and re-reference into the new instrument's components:
@@ -659,18 +661,18 @@ class Instr(Struct):
                 if second.has_component_named(at_rel.name):
                     instance.at_relative = instance.at_relative[0], second.get_component(at_rel.name)
                 else:
-                    instance.at_relative = instance.orientation.position(), None
+                    instance.at_relative = orig_orientations[instance.name].position(), None
             if isinstance(rot_rel, Instance):
                 if second.has_component_named(rot_rel.name):
                     instance.rotate_relative = instance.rotate_relative[0], second.get_component(rot_rel.name)
                 else:
-                    instance.rotate_relative = instance.orientation.angles(), None
+                    instance.rotate_relative = orig_orientations[instance.name].angles(), None
         if second.check_instrument_parameters(remove=remove_unused_parameters) and not remove_unused_parameters:
             logger.info(f'Instrument {second.name} has unused instrument parameters')
 
         return first, second
 
-    def make_instance(self, name, component, at_relative=None, rotate_relative=None, orientation=None,
+    def make_instance(self, name, component, at_relative=None, rotate_relative=None,
                       parameters=None, group=None, removable=False):
         if parameters is None:
             parameters = tuple()
@@ -680,8 +682,30 @@ class Instr(Struct):
             from ..reader import Reader
             reader = Reader(registries=list(self.registries))
             component = reader.get_component(component)
-        self.components += (Instance(name, component, at_relative, rotate_relative, orientation,
+        self.components += (Instance(name, component, at_relative, rotate_relative,
                                      parameters, group, removable),)
+
+    def resolve_orientations(self) -> dict:
+        """Resolve absolute orientations for every component in declaration order.
+
+        Returns a ``dict[str, Orient]`` mapping each component name to its
+        fully-resolved absolute :class:`~mccode_antlr.instr.orientation.Orient`.
+        Components must reference only earlier-defined components, which is
+        enforced by the McCode language, so the list is already topologically
+        sorted.
+        """
+        from .orientation import Orient
+        resolved: dict = {}
+        for inst in self.components:
+            at, at_ref = inst.at_relative
+            rt, rt_ref = inst.rotate_relative
+            ar = resolved.get(at_ref.name) if at_ref is not None else None
+            rr = resolved.get(rt_ref.name) if rt_ref is not None else None
+            if at_ref is rt_ref:
+                resolved[inst.name] = Orient.from_dependent_orientation(ar, at, rt)
+            else:
+                resolved[inst.name] = Orient.from_dependent_orientations(ar, at, rr, rt)
+        return resolved
 
     def mcpl_split(self,
                    after,
@@ -719,7 +743,7 @@ class Instr(Struct):
         # remove the last component, since we're going to re-use its name:
         first.components = first.components[:-1]
         # automatically adds the component at the end of the list:
-        first.make_instance(fc.name, output_component, fc.at_relative, fc.rotate_relative, fc.orientation,
+        first.make_instance(fc.name, output_component, fc.at_relative, fc.rotate_relative,
                             output_parameters)
 
         if input_component is None:
@@ -730,11 +754,6 @@ class Instr(Struct):
             input_parameters = (filename_parameter,) + input_parameters
         if not any(p.name == 'verbose' for p in input_parameters):
             input_parameters = (ComponentParameter('verbose', Expr.float(0)),) + input_parameters
-        # # the MCPL input component _is_ the origin of its simulation, but must be placed relative to other components.
-        # # so we need the *absolute* position and orientation of the removed component:
-        # abs_at_rel = fc.orientation.position(), None
-        # abs_rot_rel = fc.orientation.angles(), None
-
         # the split at component in the second instrument should have already been converted to absolute-positioning:
         sc = second.components[0]
         if sc.at_relative[1] is not None or sc.rotate_relative[1] is not None:
@@ -823,7 +842,7 @@ def _orient_is_constant(orient) -> bool:
         return False
 
 
-def _midpoint_at_relative(pred_inst, succ_inst):
+def _midpoint_at_relative(pred_inst, succ_inst, orientations: dict):
     """Return ``(Vector, reference_instance)`` for the midpoint between *pred_inst* and *succ_inst*.
 
     If *pred_inst* is ``None``, returns the origin ABSOLUTE.
@@ -841,8 +860,8 @@ def _midpoint_at_relative(pred_inst, succ_inst):
     if succ_inst is None:
         return zero, pred_inst
 
-    p_or = pred_inst.orientation
-    s_or = succ_inst.orientation
+    p_or = orientations.get(pred_inst.name)
+    s_or = orientations.get(succ_inst.name)
     if _orient_is_constant(p_or) and _orient_is_constant(s_or):
         p_pos = p_or.position()
         s_pos = s_or.position()
@@ -856,7 +875,7 @@ def _midpoint_at_relative(pred_inst, succ_inst):
     return zero, pred_inst
 
 
-def _downstream_rotate_relative(pred_inst, succ_inst):
+def _downstream_rotate_relative(pred_inst, succ_inst, orientations: dict):
     """Return ``(Angles, reference_instance)`` matching the orientation of the downstream component.
 
     Expresses the rotation RELATIVE to *pred_inst* when possible (matching the
@@ -876,20 +895,23 @@ def _downstream_rotate_relative(pred_inst, succ_inst):
 
     if pred_inst is None:
         # No predecessor: use absolute orientation of downstream if available
-        if _orient_is_constant(downstream.orientation):
-            return downstream.orientation.angles(), None  # ABSOLUTE
+        d_or = orientations.get(downstream.name)
+        if _orient_is_constant(d_or):
+            return d_or.angles(), None  # ABSOLUTE
         return zero, None
 
     # Both pred and succ (or just pred) exist: prefer RELATIVE to pred_inst
-    if not _orient_is_constant(pred_inst.orientation):
+    p_or = orientations.get(pred_inst.name)
+    if not _orient_is_constant(p_or):
         return zero, pred_inst  # pred orientation unknown — use zero RELATIVE pred
 
-    if downstream is pred_inst or not _orient_is_constant(downstream.orientation):
+    d_or = orientations.get(downstream.name)
+    if downstream is pred_inst or not _orient_is_constant(d_or):
         return zero, pred_inst  # no downstream info — zero RELATIVE pred
 
     # R_rel = R_succ * R_pred^T  (rotation of succ expressed in pred's frame)
-    r_pred = pred_inst.orientation.rotation('axes')
-    r_succ = downstream.orientation.rotation('axes')
+    r_pred = p_or.rotation('axes')
+    r_succ = d_or.rotation('axes')
     r_rel = r_succ * r_pred.inverse()
     angles = axes_euler_angles(r_rel, degrees=True)
     return angles, pred_inst
@@ -912,7 +934,7 @@ def _normalise_vr(vr, components, vec_cls):
     return vec, ref
 
 
-def _fix_forward_ref(at_relative, insert_idx, pred_inst):
+def _fix_forward_ref(at_relative, insert_idx, pred_inst, orientations: dict):
     """Re-express *at_relative* relative to *pred_inst* if its reference comes after *insert_idx*.
 
     If the reference component's index >= *insert_idx* (i.e., it will come
@@ -926,24 +948,11 @@ def _fix_forward_ref(at_relative, insert_idx, pred_inst):
     if ref_inst is None or pred_inst is None:
         return at_relative  # ABSOLUTE or no predecessor — nothing to fix
 
-    # We need to know the index of ref_inst in the *current* (pre-insertion) tuple.
-    # This helper is called before the new component is spliced in, so the tuple
-    # is still the original.  We can't index into self.components here, but the
-    # caller holds insert_idx which is the insertion point in the original order.
-    # We compare by object identity: if ref_inst IS one of the post-insertion
-    # components, it was added later.  For simplicity, compare by name to
-    # determine whether it precedes insert_idx; the caller must supply the
-    # original component list indirectly through pred_inst position.
-    #
-    # We detect a forward reference by checking if ref_inst is the succ_inst
-    # or comes after it.  Since we can't access the full list here, the check
-    # is deferred: if ref_inst.orientation is set AND pred_inst.orientation is
-    # set, we can convert; otherwise we trust the caller supplied a valid ref.
     if ref_inst is pred_inst:
         return at_relative  # already relative to pred — nothing to do
 
-    ref_or = ref_inst.orientation if hasattr(ref_inst, 'orientation') else None
-    pred_or = pred_inst.orientation if hasattr(pred_inst, 'orientation') else None
+    ref_or = orientations.get(ref_inst.name)
+    pred_or = orientations.get(pred_inst.name)
     if not _orient_is_constant(ref_or) or not _orient_is_constant(pred_or):
         raise RuntimeError(
             f"Cannot re-express position relative to {pred_inst.name!r}: "
@@ -957,7 +966,7 @@ def _fix_forward_ref(at_relative, insert_idx, pred_inst):
     return at_in_pred, pred_inst
 
 
-def _fix_forward_ref_rotation(rotate_relative, insert_idx, pred_inst):
+def _fix_forward_ref_rotation(rotate_relative, insert_idx, pred_inst, orientations: dict):
     """Re-express *rotate_relative* RELATIVE to *pred_inst* if its reference is forward.
 
     Computes the absolute rotation of the reference and then expresses it
@@ -973,18 +982,16 @@ def _fix_forward_ref_rotation(rotate_relative, insert_idx, pred_inst):
     if ref_inst is pred_inst:
         return rotate_relative
 
-    ref_or = ref_inst.orientation if hasattr(ref_inst, 'orientation') else None
-    pred_or = pred_inst.orientation if hasattr(pred_inst, 'orientation') else None
+    ref_or = orientations.get(ref_inst.name)
+    pred_or = orientations.get(pred_inst.name)
     if not _orient_is_constant(ref_or) or not _orient_is_constant(pred_or):
         raise RuntimeError(
             f"Cannot re-express rotation relative to predecessor: "
             f"orientation of {ref_inst.name!r} or {pred_inst.name!r} is unavailable or non-constant."
         )
 
-    from .orientation import axes_euler_angles
-    from ..common import Expr
+    from .orientation import axes_euler_angles, Rotation
     # Absolute rotation of the original (ref + angles)
-    from .orientation import Rotation
     r_angles = Rotation.from_angles(angles)
     r_abs = r_angles * ref_or.rotation('axes')
     # Express relative to pred_inst

--- a/src/mccode_antlr/instr/visitor.py
+++ b/src/mccode_antlr/instr/visitor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from ..grammar import McInstrParser, McInstrVisitor
-from ..common import InstrumentParameter, MetaData, Expr, Mode
+from ..common import InstrumentParameter, MetaData, Expr
 from ..common.visitor import add_common_visitors
 from .instr import Instr
 from .instance import Instance
@@ -15,14 +15,13 @@ def literal_string(ctx):
 
 
 class InstrVisitor(McInstrVisitor):
-    def __init__(self, parent, filename, destination=None, allow_assignment=False, mode: Mode | None = None):
+    def __init__(self, parent, filename, destination=None, allow_assignment=False):
         self.parent = parent
         self.filename = filename
         self.state = Instr()
         self.current_comp = None
         self.current_instance_name = None
         self.destination = destination
-        self.mode = mode or Mode.normal
 
     def visitProg(self, ctx: McInstrParser.ProgContext):
         self.state = Instr()
@@ -124,7 +123,7 @@ class InstrVisitor(McInstrVisitor):
             # We must use *the same* relative information for the rotation -- at[1] is None or a valid instance:
             rotate = (Angles(Expr.integer(0), Expr.integer(0), Expr.integer(0)), at[1])
         # Construct a new instance, possibly copying values from an existing instance:
-        instance = Instance.from_instance(name, comp, at, rotate) if is_ref else Instance(name, comp, at, rotate, mode=self.mode)
+        instance = Instance.from_instance(name, comp, at, rotate) if is_ref else Instance(name, comp, at, rotate)
         if ctx.instance_parameters() is not None:
             for param_name, param_value in self.visit(ctx.instance_parameters()):
                 instance.set_parameter(param_name, param_value, overwrite=is_ref)

--- a/src/mccode_antlr/io/hdf5.py
+++ b/src/mccode_antlr/io/hdf5.py
@@ -88,7 +88,7 @@ class InstanceIO:
     from mccode_antlr.comp import Comp
     from mccode_antlr.instr import Instance
     attrs = ('name', 'removable', 'cpu', 'group')
-    names = ('orientation', 'parameters', 'split', 'when', 'extend', 'jump', 'metadata')
+    names = ('parameters', 'split', 'when', 'extend', 'jump', 'metadata')
 
     @staticmethod
     def load(group, instances: dict[str, Instance], components: dict[str, Comp], **kwargs) -> Instance:

--- a/src/mccode_antlr/io/utils.py
+++ b/src/mccode_antlr/io/utils.py
@@ -11,9 +11,7 @@ from mccode_antlr.instr import Instance, Instr, Group
 from mccode_antlr.common import InstrumentParameter, MetaData, ComponentParameter, RawC
 from mccode_antlr.common.expression import Expr
 from mccode_antlr.instr.jump import Jump
-from mccode_antlr.instr.orientation import (Matrix, Vector, Angles, Rotation, Seitz,
-                                            RotationX, RotationY, RotationZ,
-                                            TranslationPart, Orient, Parts, Part)
+from mccode_antlr.instr.orientation import (Matrix, Vector, Angles, Rotation, Seitz, Orient)
 from mccode_antlr.common.metadata import DataSource
 
 MODEL_ENC = {
@@ -32,12 +30,6 @@ MODEL_ENC = {
     Angles: 'Angles',
     Rotation: 'Rotation',
     Seitz: 'Seitz',
-    RotationX: 'RotationX',
-    RotationY: 'RotationY',
-    RotationZ: 'RotationZ',
-    TranslationPart: 'TranslationPart',
-    Parts: 'Parts',
-    Part: 'Part',
     DataSource: 'DataSource',
 }
 MODEL_DEC = {v: k for k, v in MODEL_ENC.items()}

--- a/src/mccode_antlr/io/utils.py
+++ b/src/mccode_antlr/io/utils.py
@@ -36,12 +36,13 @@ MODEL_ENC = {
     RotationY: 'RotationY',
     RotationZ: 'RotationZ',
     TranslationPart: 'TranslationPart',
-    Orient: 'Orient',
     Parts: 'Parts',
     Part: 'Part',
     DataSource: 'DataSource',
 }
 MODEL_DEC = {v: k for k, v in MODEL_ENC.items()}
+# Orient is no longer written but keep decoding support for files produced by older versions.
+MODEL_DEC['Orient'] = Orient
 # Legacy type names from old ExprNode-based serialization — map to Expr
 LEGACY_EXPR_TYPES = {'Value', 'UnaryOp', 'BinaryOp', 'TrinaryOp'}
 

--- a/src/mccode_antlr/reader/reader.py
+++ b/src/mccode_antlr/reader/reader.py
@@ -5,7 +5,6 @@ from msgspec import Struct, field
 
 from .registry import Registry, registries_match, registry_from_specification
 from ..comp import Comp
-from ..common import Mode
 
 from mccode_antlr import Flavor
 
@@ -291,7 +290,7 @@ class Reader(Struct):
         self.components.pop(name, None)
         component_cache.clear_override(name)
 
-    def get_instrument(self, name: str | None | Path, destination=None, mode: Mode | None = None):
+    def get_instrument(self, name: str | None | Path, destination=None):
         """Load and parse an instr Instrument definition file
 
         In McCode3 fashion, the instrument file *should* be in the current working directory.
@@ -320,7 +319,7 @@ class Reader(Struct):
         )
         tree = McInstr_parse(stream, 'prog', error_listener)
 
-        visitor = InstrVisitor(self, filename, destination=destination, mode=mode)
+        visitor = InstrVisitor(self, filename, destination=destination)
         res = visitor.visitProg(tree)
         if not isinstance(res, Instr):
             raise RuntimeError(f'Parsing instrument file {filename} did not produce an Instr object')

--- a/tests/instr/test_positioning.py
+++ b/tests/instr/test_positioning.py
@@ -17,24 +17,26 @@ class TestInstrPositioning(TestCase):
         from mccode_antlr.instr.orientation import Vector, Rotation
         z, o = Expr.float(0), Expr.float(1)
 
-        left = instr.get_component('left')
+        orientations = instr.resolve_orientations()
+
+        left_or = orientations['left']
         v3 = Vector(z, z, o)
-        self.assertEqual(v3, left.orientation.position())
-        self.assertEqual(Rotation(z, z, -o, z, o, z, o, z, z), left.orientation.rotation())
-        self.assertEqual(left.orientation.rotation(), left.orientation.rotation('coordinates').inverse())
+        self.assertEqual(v3, left_or.position())
+        self.assertEqual(Rotation(z, z, -o, z, o, z, o, z, z), left_or.rotation())
+        self.assertEqual(left_or.rotation(), left_or.rotation('coordinates').inverse())
 
-        up = instr.get_component('up')
+        up_or = orientations['up']
         v4 = Vector(o, z, z)
-        self.assertEqual(v4, up.orientation.position() - left.orientation.position())
+        self.assertEqual(v4, up_or.position() - left_or.position())
         up_orientation = Rotation(z, z, -o, -o, z, z, z, o, z)
-        self.assertRotationsEqual(up_orientation, up.orientation.rotation())
-        self.assertEqual(Vector(o, z, o), up.orientation.position())
-        self.assertRotationsEqual(up_orientation, up.orientation.rotation('coordinates').inverse())
+        self.assertRotationsEqual(up_orientation, up_or.rotation())
+        self.assertEqual(Vector(o, z, o), up_or.position())
+        self.assertRotationsEqual(up_orientation, up_or.rotation('coordinates').inverse())
 
-        last = instr.get_component('last')
+        last_or = orientations['last']
         v5 = Vector(z, o, z)
-        self.assertRotationsEqual(up_orientation, last.orientation.rotation())
-        self.assertEqual(v5, last.orientation.position() - up.orientation.position())
+        self.assertRotationsEqual(up_orientation, last_or.rotation())
+        self.assertEqual(v5, last_or.position() - up_or.position())
 
     def test_assemble_positioning(self):
         from mccode_antlr.utils import make_assembler
@@ -63,10 +65,12 @@ class TestInstrPositioning(TestCase):
         from mccode_antlr.common import Expr
         from mccode_antlr.instr.orientation import Vector
         positions = {k: Vector(*[Expr.float(x) for x in v]) for k, v in positions.items()}
+        orientations = instr.resolve_orientations()
         for instance in instr.components:
-            self.assertEqual(positions[instance.name], instance.orientation.position())
-            self.assertEqual(positions[instance.name], instance.orientation.position('axes'))
-            self.assertEqual(positions[instance.name], instance.orientation.position('coordinates'))
+            orient = orientations[instance.name]
+            self.assertEqual(positions[instance.name], orient.position())
+            self.assertEqual(positions[instance.name], orient.position('axes'))
+            self.assertEqual(positions[instance.name], orient.position('coordinates'))
 
     def test_simple_positioning(self):
         from mccode_antlr.utils import parse_instr_string
@@ -92,15 +96,17 @@ class TestInstrPositioning(TestCase):
         positions = {'origin': (0, 0, 0), 'guide_start': (0.01277, 0, 1.930338), 'guide': (0.01277, 0, 1.930338),
                      'guide_end': (0.01277 - 4.33*sin(pi/180*0.56), 0, 1.930338 + 4.33*cos(pi/180*0.56))}
         self._simple_position_tests(instr, positions)
-        pos_hat = (0.006615, 0, 0.999978)
-        pos = instr.components[2].orientation.position()
+
+        orientations = instr.resolve_orientations()
+        pos = orientations['guide'].position()
         distance = pos.length()
         vector = pos / distance
+        pos_hat = (0.006615, 0, 0.999978)
         self.assertAlmostEqual(vector.x, pos_hat[0], 6)
         self.assertAlmostEqual(vector.y, pos_hat[1], 6)
         self.assertAlmostEqual(vector.z, pos_hat[2], 6)
         self.assertAlmostEqual(distance, 1.930380239005777, 6)
 
         # Combining the position and rotation (reduced) operations should yield the same position
-        comb = instr.components[2].orientation.combine().reduce()
+        comb = orientations['guide'].combine().reduce()
         self.assertEqual(pos, comb.position())

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -501,43 +501,6 @@ class TestOrientation(TestCase):
         self.assertEqual(d2.position(), t444.position())
         self.assertEqual(d2.angles(), a000)
 
-    # def test_DependentOrientation_with_rotations(self):
-    #     from mccode_antlr.common import Expr
-    #     from mccode_antlr.instr.orientation import TranslationPart, Vector, Angles
-    #     from mccode_antlr.instr.orientation import RotationX, RotationY, RotationZ
-    #     from mccode_antlr.instr.orientation import OrientParts, Orient
-    #
-    #     tx, ty, tz = _random_angles_degrees()
-    #     f = Expr.float
-    #
-    #     for a in (Angles(tx, f(0), f(0)), Angles(f(0), ty, f(0)), Angles(f(0), f(0), tz)):
-    #         v = _random_vector(0.1, 1.0)
-    #         dop = Orient.from_dependent_orientation(None, v, a)
-    #         self.assertEqual(dop.position(), v)
-    #         self.assertEqual(dop.angles(), a)
-    #         print(dop)
-    #
-    #     # Rotate 90 degrees around z axis
-    #     z90 = Angles(f(0), f(0), f(90))
-    #     # Then rotate 90 degrees around x axis
-    #     x90 = Angles(f(90), f(0), f(0))
-    #     # This permutes the axes x'=y, y'=z, z'=x
-    #     xyz = Orient()
-    #     inter = Orient.from_dependent_orientation(xyz, Vector(f(0), f(0), f(0)), z90)
-    #     yzx = Orient.from_dependent_orientation(inter, Vector(f(0), f(0), f(0)), x90)
-    #
-    #     self.assertEqual(yzx._position.resolve().seitz(), yzx._rotation.resolve().seitz())
-    #
-    #     self.assertNotEqual(yzx.angles(), Angles(f(90), f(0), f(90)))
-    #     self.assertEqual(yzx.angles(), Angles(f(180), f(90), f(-90)))
-    #
-    #
-    #     #
-    #     # d2 = DependentOrientation.from_dependent_orientation(dop, v321, a000)
-    #     # t444 = OrientationParts((t123, t321)).reduce().stack()[0]
-    #     # self.assertEqual(d2.position(), t444.position())
-    #     # self.assertEqual(d2.angles(), a000)
-
     def test_DependentOrientation_simple(self):
         from mccode_antlr.common import Expr
         from mccode_antlr.instr.orientation import Vector, Angles, Orient


### PR DESCRIPTION
This pull request refactors how component orientations are handled throughout the codebase. It removes the `orientation` attribute from the `Instance` class and centralizes orientation computation in a new `resolve_orientations` method on the `Instr` class. This change simplifies instance data structures, ensures consistent orientation handling, and updates all relevant code to use the new approach.

**Refactor: Centralized Orientation Handling**

* Added `Instr.resolve_orientations()` to compute and return a mapping of component names to their resolved orientations, replacing per-instance orientation storage and computation. (Fc40b11fL682R682)
* Removed the `orientation` attribute and related logic from the `Instance` class, including its initialization, equality, copying, and deserialization methods. [[1]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL27) [[2]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL37) [[3]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL118-L139) [[4]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL271-R257) [[5]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL332-L338) [[6]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fR325-R328)

**Codebase Updates for Orientation Resolution**

* Updated all usages of instance orientations in display and rendering modules (`instrument_display.py`, `brep.py`, `plotly.py`) to use the new `resolve_orientations()` method. [[1]](diffhunk://#diff-16602f5530049c97261d47a8da1511ff4e0a3f173689c8b1b393973295adfad2R130) [[2]](diffhunk://#diff-16602f5530049c97261d47a8da1511ff4e0a3f173689c8b1b393973295adfad2L149-L155) [[3]](diffhunk://#diff-09b9b35e9b8632b34b927adbd16e88606c681a097d96682cf2dd8436583d7f3aR426) [[4]](diffhunk://#diff-09b9b35e9b8632b34b927adbd16e88606c681a097d96682cf2dd8436583d7f3aL459-L461) [[5]](diffhunk://#diff-14ba1ea11fd819cd71714676e088be1e340c2c99e9235ae921c3870a884ce27cL90-R93)
* Modified insertion and splitting logic in `Instr` to use resolved orientations for position and rotation calculations, ensuring correct placement and reference fixing. [[1]](diffhunk://#diff-106dc8946ecadb2b3f1e40c86bce60039a9242bec7c65aade40c6c4f8f9ef07dR339-R352) [[2]](diffhunk://#diff-106dc8946ecadb2b3f1e40c86bce60039a9242bec7c65aade40c6c4f8f9ef07dL366-R367) [[3]](diffhunk://#diff-106dc8946ecadb2b3f1e40c86bce60039a9242bec7c65aade40c6c4f8f9ef07dR653) [[4]](diffhunk://#diff-106dc8946ecadb2b3f1e40c86bce60039a9242bec7c65aade40c6c4f8f9ef07dL662-R675) [[5]](diffhunk://#diff-106dc8946ecadb2b3f1e40c86bce60039a9242bec7c65aade40c6c4f8f9ef07dL722-R746)

**Code Cleanup**

* Removed the obsolete `Mode` enum and all references to it, as minimal/non-minimal orientation handling is now unified. [[1]](diffhunk://#diff-06678aea66c82b5bccd504d7f1c51f29bf1afe5b43bd19ec446409bf6eefc22fL1-L5) [[2]](diffhunk://#diff-7ea5e18d124d17864fa3285b0fcf38350f396d203d6fc6261a87b96933fbd24dL6) [[3]](diffhunk://#diff-7ea5e18d124d17864fa3285b0fcf38350f396d203d6fc6261a87b96933fbd24dL20) [[4]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL8-R10)
* Updated docstrings and comments to reflect the new orientation resolution approach. [[1]](diffhunk://#diff-16602f5530049c97261d47a8da1511ff4e0a3f173689c8b1b393973295adfad2L5-R7) [[2]](diffhunk://#diff-3a80a7962d80522866edf4453511f4bc060507abdbe1bd4f25ecd1840610f91fL358)

These changes greatly simplify the instrument and component data model, ensure consistent orientation computation, and reduce the risk of bugs due to per-instance state.