### PR TITLE
Fix issues with pre-compiled binary execution

### DIFF
--- a/src/mccode_antlr/compiler/c.py
+++ b/src/mccode_antlr/compiler/c.py
@@ -400,10 +400,53 @@ def compile_c_file(
     return output
 
 
+def infer_binary_target(binary: Path, count: int = 1) -> CBinaryTarget:
+    """Infer a CBinaryTarget by scanning the compiled binary for known symbols.
+
+    Checks for canonical MPI and OpenACC entry-point names in the binary.
+    These appear in the import table (dynamically linked) or the symbol
+    table / string pool (statically linked), so no external tooling is
+    required and the approach works on Windows, Linux, and macOS.
+
+    The file is memory-mapped rather than fully loaded, so large binaries are
+    handled without exhausting RAM.
+
+    The ``count`` (number of MPI processes) cannot be inferred from the binary;
+    callers should pass the value from CLI flags or use the default of 1.
+
+    Parameters
+    ----------
+    binary:
+        Path to the compiled instrument binary to inspect.
+    count:
+        Number of MPI processes to use; cannot be determined from the binary.
+    """
+    import mmap
+    _mpi_markers = [b'MPI_Init', b'MPI_Finalize', b'MPI_Comm_size']
+    _acc_markers = [b'acc_init', b'acc_shutdown', b'_acc_present']
+    try:
+        with open(binary, 'rb') as f:
+            with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
+                mpi = any(mm.find(m) != -1 for m in _mpi_markers)
+                acc = any(mm.find(m) != -1 for m in _acc_markers)
+    except (IOError, OSError, ValueError):
+        logger.warning(f"Could not read {binary} to infer target type; assuming single-threaded")
+        return CBinaryTarget(count=count)
+    return CBinaryTarget(mpi=mpi, acc=acc, count=count)
+
+
 def run_compiled_instrument(binary: Path, target: CBinaryTarget, options: str, capture=False, dry_run: bool = False):
     from subprocess import run, CalledProcessError
     from platform import system
     from mccode_antlr.config import config
+
+    if not isinstance(target, CBinaryTarget):
+        _t = CBinaryTarget()
+        if isinstance(target, dict):
+            _t.update(target)
+        else:
+            raise TypeError(f"target must be a CBinaryTarget, got {type(target)}")
+        target = _t
 
     # If NeXus output is requested and the InstrumentDescriptionFile is needed, run a different script entirely...
     #   TODO think about actually doing this?

--- a/src/mccode_antlr/run/runner.py
+++ b/src/mccode_antlr/run/runner.py
@@ -298,10 +298,34 @@ def mccode_run_cmd(flavor: Flavor):
         use_defaults=args.yes,
     )
     # check if the filename is actually a compiled instrument already:
-    if args.output_file is None and filename.exists() and access(filename, X_OK):
+    # os.access(path, X_OK) always returns True on Windows for any existing file (no POSIX execute bit),
+    # so we must also exclude known source-file extensions to avoid treating .instr/.json/.h5 as binaries.
+    _source_suffixes = {'.instr', '.json', '.h5', '.c'}
+    if args.output_file is None and filename.exists() and access(filename, X_OK) \
+            and filename.suffix.lower() not in _source_suffixes:
+        from loguru import logger
+        from mccode_antlr.compiler.c import infer_binary_target
         binary = filename
         name = filename.stem
         has_parameters = None  # unknown for a pre-compiled binary
+        # Infer MPI/ACC type from the binary itself rather than trusting CLI flags,
+        # since the binary may have been compiled externally.
+        inferred = infer_binary_target(binary, count=target.get('count', 1))
+        # Warn if the CLI flags disagree with the binary's actual linkage.
+        cli_mpi = bool(target.get('mpi', False))
+        cli_acc = bool(target.get('acc', False))
+        from mccode_antlr.compiler.c import CBinaryTarget as _CBT
+        if cli_mpi != bool(inferred.type & _CBT.Type.mpi):
+            logger.warning(
+                f"CLI flag --parallel ({cli_mpi}) does not match MPI linkage inferred from {binary.name} "
+                f"({bool(inferred.type & _CBT.Type.mpi)}); using binary-inferred value"
+            )
+        if cli_acc != bool(inferred.type & _CBT.Type.acc):
+            logger.warning(
+                f"CLI flag --gpu ({cli_acc}) does not match OpenACC linkage inferred from {binary.name} "
+                f"({bool(inferred.type & _CBT.Type.acc)}); using binary-inferred value"
+            )
+        target = inferred
     elif not filename.exists() or not access(filename, R_OK):
         raise RuntimeError(f'{filename} does not exist or is not readable')
     else:


### PR DESCRIPTION
This pull request introduces improved detection and handling of compiled instrument binaries, especially regarding MPI and OpenACC support. The main changes add a function to infer binary features by scanning for known symbols, and update the CLI runner to use this information and warn if user-supplied flags disagree with the binary's actual capabilities.

**Binary feature inference and CLI integration:**

* Added `infer_binary_target` function to `src/mccode_antlr/compiler/c.py` that scans compiled binaries for known MPI and OpenACC symbols to infer their capabilities, working cross-platform without external tools.
* Updated `run_compiled_instrument` to ensure the `target` argument is always a `CBinaryTarget` instance, improving type safety.

**Runner logic improvements:**

* In `src/mccode_antlr/run/runner.py`, improved detection of binaries by excluding known source file extensions, avoiding accidental execution of source files as binaries (especially important on Windows).
* The runner now uses `infer_binary_target` to determine if a binary supports MPI or OpenACC, warning the user if CLI flags do not match the binary's actual linkage, and prioritizing the inferred values.