### PR TITLE
Fix: prefetch_data_files() re-resolves an already-absolute path

### DIFF
--- a/src/mccode_antlr/translators/target.py
+++ b/src/mccode_antlr/translators/target.py
@@ -191,7 +191,7 @@ class TargetVisitor:
                     fullname = reg.fullname(name)
                     if fullname is None or f'data/{name}' not in str(fullname).replace('\\', '/'):
                         continue
-                    cached = reg.path(fullname)
+                    cached = reg.path(name)
                     logger.info(
                         f'{self.source.name}: pre-fetched data file {name!r} '
                         f'-> {cached}'


### PR DESCRIPTION
TargetVisitor.prefetch_data_files() computed fullname = reg.fullname(name), then called reg.path(fullname) instead of reg.path(name). For LocalRegistry, fullname() already returns a fully-resolved absolute Path (unlike RemoteRegistry.fullname(), which returns a relative pooch-registry string) -- so this fed an absolute path back into a lookup that internally globs self.root against it.

Python <=3.12's pathlib silently tolerated Path.glob() with an absolute pattern; the Python 3.13+ pathlib rewrite raises
NotImplementedError("Non-relative patterns are unsupported") instead. This made prefetch_data_files() crash under Python 3.13+ for any instrument referencing a real data file (e.g. a neutron cross-section table) through a local (-I) component search directory -- ordinary usage, no duplicate filenames or ambiguous registries required to reproduce.

Reproduced with: mcstas-antlr -I <mcstas-comps> Test_PSD_Detector.instr (references Gas_tables/He3inHe.table), traced to this line by intercepting pathlib.Path.glob and inspecting the failing call's arguments.