### PR TITLE
Improve: clear error for %include of a non-.instr target

### DIFF
--- a/src/mccode_antlr/reader/reader.py
+++ b/src/mccode_antlr/reader/reader.py
@@ -300,6 +300,16 @@ class Reader(Struct):
         from ..grammar import McInstr_parse, McInstr_ErrorListener
         from ..instr import InstrVisitor, Instr
         path = name if isinstance(name, Path) else Path(name)
+        if path.suffix not in ('', '.instr'):
+            raise RuntimeError(
+                f"%include of {str(name)!r} is not supported: mccode-antlr's %include always "
+                f"parses its target as an .instr instrument definition, so a suffix other than "
+                f".instr or no suffix (implying .instr) can never resolve. Some McStas-3 "
+                f"instruments abuse %include to splice raw file contents (e.g. generated C "
+                f"fragments) into DECLARE/INITIALIZE/TRACE sections; that pattern is not "
+                f"supported here and would need restructuring (e.g. moving the generated code "
+                f"into a real .instr/.comp, or embedding it directly) to translate with mccode-antlr."
+            )
         if path.suffix != '.instr':
             path = path.with_suffix(f'{path.suffix}.instr')
         if path.exists() and path.is_file():


### PR DESCRIPTION
Reader.get_instrument() (used for every %include target, not just top-level CLI invocations) unconditionally coerced any suffix into .instr via path.with_suffix(f'{path.suffix}.instr'). For an %include target that already has a different suffix (e.g. "battery_stack_trace.c"), this produces a nonsensical double suffix ("battery_stack_trace.c.instr"), which then fails registry lookup with a confusing "not found in registries" error that gives no hint about what actually went wrong.

Some McStas-3 instruments (e.g. examples/elearning/Radiography_Lithium_Battery) abuse %include to splice raw generated C fragments into DECLARE/INITIALIZE/ TRACE sections. Since %include always parses its target through the McInstr grammar as a full instrument definition, this usage can never work -- there's no reasonable way to "fix" it structurally. This instead fails fast with a clear, specific error explaining why and what to do about it, rather than mangling the filename and failing confusingly two steps later.

No behavior change for the normal case (suffix-less or .instr targets).