### PR TITLE
Perf: skip sympy's UnevaluatedExpr tree rewrite in McCode printers

### DIFF
--- a/src/mccode_antlr/common/expression/printer.py
+++ b/src/mccode_antlr/common/expression/printer.py
@@ -137,9 +137,19 @@ class McCodeCPrinter(C99CodePrinter):
         # to avoid SymPy's %.17g format giving e.g. '0.050000000000000003' for 0.05.
         return repr(float(expr))
 
+    def _handle_UnevaluatedExpr(self, expr):
+        # SymPy's version walks the whole tree with Basic.replace (sympifying at
+        # every node) to unwrap re(UnevaluatedExpr(x)) -- McCode never constructs
+        # UnevaluatedExpr, so skip the traversal.
+        return expr
+
 
 class McCodePyPrinter(PythonCodePrinter):
     """SymPy printer that emits McCode Python-style expressions."""
+
+    def _handle_UnevaluatedExpr(self, expr):
+        # See McCodeCPrinter._handle_UnevaluatedExpr.
+        return expr
 
     def _print_McCodeParameter(self, expr):
         return expr.name


### PR DESCRIPTION
Every `McCodeCPrinter.doprint` call inherits `CodePrinter.doprint`'s unconditional `_handle_UnevaluatedExpr` step, which traverses the entire expression with `Basic.replace(re, ...)` — `_sympify`-ing at every node — to unwrap `re(UnevaluatedExpr(x))` patterns. mccode-antlr never constructs `UnevaluatedExpr` anywhere (grep over `src/` returns zero hits), so the traversal can never change anything; it is pure per-print overhead.

Profiling translation of `ILL_H5_new` (McStas examples corpus; pyinstrument; `main` @ `92ebe47`; warm typedef cache) attributed ~15–20% of codegen time to this traversal, concentrated under `cogen_comp_setpos` → `Expr.__format__` → `doprint` → `_handle_UnevaluatedExpr` → `_sympify`.

## Fix

No-op `_handle_UnevaluatedExpr` override (return the expression unchanged) in `McCodeCPrinter` and `McCodePyPrinter` (`src/mccode_antlr/common/expression/printer.py`). Semantics-preserving as long as McCode never emits `UnevaluatedExpr`; if that ever changes, the override is one line to revisit.

## Verification / effect

- Generated C byte-identical (modulo the `Date:` header line) for `template_simple`, `ISIS_OSIRIS`, `ILL_SALSA`, `ILL_H5_new`.
- Full test suite passes.
- `ILL_H5_new` in-process codegen: 1.63s → 1.37s with this patch alone.
