### PR TITLE
Perf: memoize Expr formatting on (srepr strings, format spec)

### DIFF
--- a/src/mccode_antlr/common/expression/expr.py
+++ b/src/mccode_antlr/common/expression/expr.py
@@ -55,6 +55,10 @@ def _to_sympy(value) -> sympy.Basic:
 # Public Expr class
 # ---------------------------------------------------------------------------
 
+# Memoized Expr.__format__ results, keyed on (tuple-of-srepr-strings, format_spec).
+_FORMAT_CACHE: dict[tuple[tuple[str, ...], str], str] = {}
+
+
 class Expr(msgspec.Struct, dict=True, eq=False):
     """Symbolic expression with McCode-specific metadata."""
 
@@ -227,14 +231,22 @@ class Expr(msgspec.Struct, dict=True, eq=False):
     # ------------------------------------------------------------------
 
     def __str__(self):
-        from .printer import _C_PRINTER
-        from .sympy_classes import UNSET_SYMPY
-        # Preserve old Value(None).__str__() = 'None' for null/unset expressions
-        if len(self._exprs) == 1 and self._exprs[0] is UNSET_SYMPY:
-            return 'None'
-        return ','.join(_C_PRINTER.doprint(e) for e in self._exprs)
+        # Same output as an empty format spec (including 'None' for null/unset),
+        # routed through __format__ to share its memoization.
+        return self.__format__('')
 
     def __format__(self, format_spec):
+        # Printing is deterministic given the srepr strings and the format spec,
+        # and translation re-formats the same (component-type-shared) expressions
+        # many times over -- memoize on the srepr strings, NOT on self (whose
+        # __hash__ itself prints).
+        key = (tuple(self.exprs), format_spec)
+        result = _FORMAT_CACHE.get(key)
+        if result is None:
+            _FORMAT_CACHE[key] = result = self._format_uncached(format_spec)
+        return result
+
+    def _format_uncached(self, format_spec):
         from .printer import _C_PRINTER, _P_PRINTER
         from .sympy_classes import UNSET_SYMPY
         # Preserve 'None' for null/unset when used in format strings


### PR DESCRIPTION
## Problem

Expression printing is invoked once per use site, but the same expressions recur heavily within one translation. The clearest case: component-type parameter *defaults* are formatted once per component *instance* by `parameter_line`/`nexus_lines` (`src/mccode_antlr/translators/c_initialise.py`) — `ILL_H5_new` has 325 component instances spanning only ~17 distinct component types, so the same handful of `Expr` objects are pushed through `McCodeCPrinter.doprint` dozens of times each. `Expr.__str__` (and therefore `Expr.__hash__`, which is `hash(str(self))`) pay the same printing cost again during the parse-stage IR walk.

Printing is fully deterministic given the persisted `sympy.srepr` strings (`Expr.exprs`) and the format spec, so this is memoizable. One trap for implementers: the cache must NOT key on the `Expr` object itself, because `Expr.__hash__` invokes the printer — that would recurse into the very work being cached.

Profiling `ILL_H5_new` (pyinstrument, `main` @ `92ebe47`, warm typedef cache) put `Expr.__format__` → `doprint` at roughly 1.5s of a 3.3s codegen stage.

## Fix

Module-level memo table for `Expr.__format__` keyed on `(tuple(self.exprs), format_spec)`, with `__str__` routed through `__format__('')` to share it (`src/mccode_antlr/common/expression/expr.py`). `exprs` is normalised to srepr strings in `__post_init__` and never mutated afterwards, so the key is stable.

## Verification / effect

- Generated C byte-identical (modulo the `Date:` header line) for `template_simple`, `ISIS_OSIRIS`, `ILL_SALSA`, `ILL_H5_new`.
- Full test suite passes.
- `ILL_H5_new` in-process: codegen 1.37s → 0.54s, and parse also drops ~0.3s (IR-walk `__str__`/`__hash__` calls hit the same cache), measured with this patch applied on top of 0007.
