### PR TITLE
Perf: index LocalRegistry contents instead of re-globbing per lookup

### DIFF
--- a/src/mccode_antlr/reader/registry.py
+++ b/src/mccode_antlr/reader/registry.py
@@ -397,6 +397,7 @@ class LocalRegistry(Registry):
         self.root = Path(root)
         self.version = mccode_antlr_version()
         self.priority = priority
+        self._index = None  # lazy basename -> [paths] index of everything under root
 
     def __repr__(self):
         return f'LocalRegistry({self.name!r}, {self.root!r}, {self.priority!r})'
@@ -413,8 +414,28 @@ class LocalRegistry(Registry):
     def _filetype_iterator(self, filetype: str):
         return self.root.glob(f'**/*.{filetype}')
 
+    def _file_index(self) -> dict[str, list[Path]]:
+        # Every _file_iterator call is a full recursive walk of root (~0.2s for
+        # mcstas-comps), and one translation makes many such calls (known/
+        # fullname/path per data file, component lookups, ...). Walk once per
+        # registry instance instead; the tree is static for a translation's
+        # lifetime. Includes directories, matching glob('**/name') semantics.
+        if self._index is None:
+            import os
+            index: dict[str, list[Path]] = {}
+            for dirpath, dirnames, filenames in os.walk(self.root):
+                base = Path(dirpath)
+                for n in dirnames + filenames:
+                    index.setdefault(n, []).append(base / n)
+            self._index = index
+        return self._index
+
     def _file_iterator(self, name: str):
-        return self.root.glob(f'**/{name}')
+        # The index only answers plain basenames -- glob metacharacters or an
+        # embedded path separator still need real glob matching.
+        if any(c in name for c in '*?[') or '/' in name or '\\' in name:
+            return self.root.glob(f'**/{name}')
+        return iter(self._file_index().get(name, []))
 
     def _exact_file_iterator(self, name: str):
         return self.root.glob(name)


### PR DESCRIPTION
## Problem

`LocalRegistry.known`, `.unique` and `.fullname` (`src/mccode_antlr/reader/registry.py`) each call `_file_iterator(name)`, which runs `root.glob(f'**/{name}')` — a full recursive walk of the registry root. For a registry rooted at `mcstas-comps` that walk costs ~0.2s, and a single translation triggers it many times:

- `CTargetVisitor.prefetch_data_files` does `known` + `fullname` + `path`→`fullname` — three separate full walks — per string parameter that names a data file, per registry;
- component resolution during parsing hits `known`/`fullname` through the same path.

Profiling `ILL_H5_new` (pyinstrument, `main` @ `92ebe47`) showed 0.69s of `prefetch_data_files` spent almost entirely in three identical `glob.select_recursive` walks. The effect is not limited to big instruments: `template_simple` (one component) paid ~0.5s of its codegen to these walks.

## Fix

Lazily build a `basename → [paths]` index with a single `os.walk` per `LocalRegistry` instance (including directories, matching `glob('**/name')` semantics) and serve plain-name lookups from it. Lookups whose pattern contains glob metacharacters (`*?[`) or a path separator still fall through to real `glob`. The tree is static for the lifetime of a translation, and registries are constructed per translation, so instance-lifetime caching is safe.

## Verification / effect

- Generated C byte-identical for `template_simple`, `ISIS_OSIRIS`, `ILL_SALSA`, `ILL_H5_new`; full test suite passes.
- `ILL_H5_new` in-process codegen 0.54s → 0.19s;; `template_simple` codegen 0.49s → 0.03s.