### PR TITLE
Update dependencies and fix CI build duplication

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -3,9 +3,6 @@ name: Pip
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - main
 
 env:
   # Pin the McCode version whose component and library files are used in tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     'antlr4-python3-runtime>=4.13.2',
     'numpy>=2',
     'pooch>=1.7.0',
-    'confuse==2.1.0',
+    'confuse==2.2.1',
     'loguru>=0.7.2',
     'gitpython>=3.1.43',
     'msgspec>=0.19.0',
@@ -21,7 +21,6 @@ dependencies = [
     'packaging',
     'pyyaml',
     "networkx>=3.0",
-    "typing_extensions>=4.9.0"
 ]
 description = "ANTLR4 grammars for McStas and McXtrace"
 readme = "README.md"

--- a/src/mccode_antlr/loader/datfile.py
+++ b/src/mccode_antlr/loader/datfile.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from typing_extensions import deprecated
-
 from dataclasses import dataclass, field
 from typing import Any, Union
 from pathlib import Path
+
+from mccode_antlr.utils import deprecated
 
 
 def _require_scipp():
@@ -96,7 +96,7 @@ class DatFileCommon:
         return self.metadata.get('variables', '').split()
 
     @property
-    @deprecated("Access 'I' (with variance) or 'N' via getitem method")
+    @deprecated(since="0.20.1", replacement="Use {object}['I'] (with variance) or {object}['N'] in place of {object}.data", remove_in=None)
     def data(self):
         """Datafile values as a numpy array (backward compat).
 

--- a/src/mccode_antlr/test.py
+++ b/src/mccode_antlr/test.py
@@ -67,7 +67,7 @@ def ipython_available():
 
 
 def ipython_test(method):
-    if not scipp_available():
+    if not ipython_available():
         @pytest.mark.skip(reason='ipython is not available')
         def no_ipython(*args, **kwargs):
             return method(*args, **kwargs)


### PR DESCRIPTION
- confuse 2.2.1 fixes the missing-transient-dependency bug for Python<3.13.
- By using mccode_antlr.util.deprecated instead of typing_extensions.deprecated we can drop an explicit dependency on the typing_extensions module.
- A typo in the test decorator for IPython tests prevented skipping in the case where `scipp` (but not `ipython`) is importable.
- The pip.yml workflow ran for pull requests _and_ merges into main after an approved pull request; since there are branch protection rules for main this (typically) causes an exact duplication of CI runs. Repository admins are able to bypass the branch protections including pushing directly to main, which now could allow additions which go untested; but this will be mitigated through vigilance.